### PR TITLE
fix: prevent panic in parse_trace_id_randomness on malformed input

### DIFF
--- a/src/engine/sampling.rs
+++ b/src/engine/sampling.rs
@@ -137,11 +137,13 @@ pub(crate) fn parse_tracestate_rv(tracestate: &str) -> Option<u64> {
 ///
 /// The TraceID is a 32-character hex string. We take the last 14 hex
 /// characters (least-significant 56 bits) as the randomness value.
+///
+/// Returns `None` for strings shorter than 14 bytes, strings where the
+/// 14-byte boundary falls inside a multi-byte UTF-8 character, and strings
+/// whose last 14 characters are not valid hex.
 pub(crate) fn parse_trace_id_randomness(trace_id: &str) -> Option<u64> {
-    if trace_id.len() < 14 {
-        return None;
-    }
-    let suffix = &trace_id[trace_id.len() - 14..];
+    let offset = trace_id.len().checked_sub(14)?;
+    let suffix = trace_id.get(offset..)?;
     u64::from_str_radix(suffix, 16)
         .ok()
         .map(|v| v & RANDOMNESS_MASK)
@@ -466,6 +468,19 @@ mod tests {
         assert_eq!(result.unwrap(), expected);
 
         assert_eq!(parse_trace_id_randomness("abc"), None);
+    }
+
+    #[test]
+    fn parse_trace_id_randomness_non_hex_returns_none() {
+        // Non-hex suffix returns None (not a panic).
+        assert_eq!(parse_trace_id_randomness("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"), None);
+        // Multibyte UTF-8 char whose byte boundary falls at offset len-14 returns None.
+        // "1é23456789012": len=15 bytes, offset=1 is the continuation byte of 'é'.
+        assert_eq!(parse_trace_id_randomness("1\u{00e9}23456789012"), None);
+        // Non-ASCII that is valid at the boundary (len-14 is a char boundary) but non-hex.
+        // Empty/short strings.
+        assert_eq!(parse_trace_id_randomness(""), None);
+        assert_eq!(parse_trace_id_randomness("short"), None);
     }
 
     // ==================== parse_tracestate_th tests ====================


### PR DESCRIPTION
## Summary

- `parse_trace_id_randomness` used a raw byte-indexed slice (`&s[len-14..]`) which panics when `len-14` falls inside a multi-byte UTF-8 character (e.g. an adapter that accidentally passes a non-hex trace ID containing a 2-byte char like `é`)
- Replaced with `checked_sub(14)?` + `str::get(offset..)?`, returning `None` instead of panicking
- Added a test covering multibyte-boundary input and other non-hex inputs

## Test plan

- [ ] `cargo test parse_trace_id_randomness` passes
- [ ] `"1\u{00e9}23456789012"` (multibyte at byte offset 1 = continuation byte) returns `None` instead of panicking