### PR TITLE
feat: implement policy spec v1.5.0 — typed and numeric matchers

### DIFF
--- a/proto/tero/policy/v1/log.proto
+++ b/proto/tero/policy/v1/log.proto
@@ -78,6 +78,9 @@ enum LogField {
   // Log record fields
   LOG_FIELD_BODY = 1;
   LOG_FIELD_SEVERITY_TEXT = 2;
+  // trace_id and span_id are bytes. They are authored as lowercase hex and
+  // matched as raw bytes (exact/equals), or as their hex rendering for string
+  // match types.
   LOG_FIELD_TRACE_ID = 3;
   LOG_FIELD_SPAN_ID = 4;
   LOG_FIELD_EVENT_NAME = 5;
@@ -119,24 +122,43 @@ message LogMatcher {
   }
 
   // Match type. Exactly one must be set.
+  //
+  // The string match types (exact, regex, starts_with, ends_with, contains)
+  // operate only on string field values. To match non-string values, use the
+  // typed equals matcher or the numeric comparison matchers (gt, gte, lt, lte).
   oneof match {
-    // Exact string match
+    // Exact string match (string field values only)
     string exact = 10;
 
-    // Regular expression match
+    // Regular expression match (string field values only)
     string regex = 11;
 
     // Field existence check
     bool exists = 12;
 
-    // Literal prefix match
+    // Literal prefix match (string field values only)
     string starts_with = 13;
 
-    // Literal suffix match
+    // Literal suffix match (string field values only)
     string ends_with = 14;
 
-    // Literal substring match
+    // Literal substring match (string field values only)
     string contains = 15;
+
+    // Typed equality for non-string field values (bool, int, double, bytes)
+    Value equals = 22;
+
+    // Numeric greater-than comparison (int/double field values)
+    NumericValue gt = 23;
+
+    // Numeric greater-than-or-equal comparison (int/double field values)
+    NumericValue gte = 24;
+
+    // Numeric less-than comparison (int/double field values)
+    NumericValue lt = 25;
+
+    // Numeric less-than-or-equal comparison (int/double field values)
+    NumericValue lte = 26;
   }
 
   // If true, inverts the match result

--- a/proto/tero/policy/v1/metric.proto
+++ b/proto/tero/policy/v1/metric.proto
@@ -99,24 +99,43 @@ message MetricMatcher {
 
   // Match type. Exactly one must be set.
   // Note: For metric_type field, only exists is valid (type equality is implicit).
+  //
+  // The string match types (exact, regex, starts_with, ends_with, contains)
+  // operate only on string field values. To match non-string values, use the
+  // typed equals matcher or the numeric comparison matchers (gt, gte, lt, lte).
   oneof match {
-    // Exact string match
+    // Exact string match (string field values only)
     string exact = 10;
 
-    // Regular expression match
+    // Regular expression match (string field values only)
     string regex = 11;
 
     // Field existence check
     bool exists = 12;
 
-    // Literal prefix match
+    // Literal prefix match (string field values only)
     string starts_with = 13;
 
-    // Literal suffix match
+    // Literal suffix match (string field values only)
     string ends_with = 14;
 
-    // Literal substring match
+    // Literal substring match (string field values only)
     string contains = 15;
+
+    // Typed equality for non-string field values (bool, int, double, bytes)
+    Value equals = 22;
+
+    // Numeric greater-than comparison (int/double field values)
+    NumericValue gt = 23;
+
+    // Numeric greater-than-or-equal comparison (int/double field values)
+    NumericValue gte = 24;
+
+    // Numeric less-than comparison (int/double field values)
+    NumericValue lt = 25;
+
+    // Numeric less-than-or-equal comparison (int/double field values)
+    NumericValue lte = 26;
   }
 
   // If true, inverts the match result

--- a/proto/tero/policy/v1/shared.proto
+++ b/proto/tero/policy/v1/shared.proto
@@ -50,3 +50,43 @@ message AttributePath {
   // Multiple elements traverse nested maps.
   repeated string path = 1;
 }
+
+// Value carries a typed, non-string scalar for the `equals` matcher. String
+// equality is expressed with the `exact` match type, so this message
+// intentionally has no string variant.
+//
+// `equals` matches when the field value has the same type and value as the set
+// variant. Integer and floating-point values are compared in a single numeric
+// domain (an int_value may match a double field with an equal numeric value and
+// vice versa). All other type pairings do not match.
+//
+// Bytes are authored either as proto-native base64 (`bytes_value`) or as a
+// lowercase-hex string (`hex_value`). The two are equivalent — hex_value is
+// decoded to bytes at policy-compile time. A bare string literal MUST be
+// rejected — use `exact` for strings.
+message Value {
+  // Exactly one must be set.
+  oneof value {
+    bool bool_value = 1;
+    int64 int_value = 2;
+    double double_value = 3;
+    // Raw bytes (base64 in proto JSON).
+    bytes bytes_value = 4;
+    // Bytes encoded as a hexadecimal string (even length; case-insensitive on
+    // input, canonically lowercase). Decoded to bytes at policy-compile time;
+    // an invalid hex string MUST be rejected.
+    string hex_value = 5;
+  }
+}
+
+// NumericValue carries a typed number for the comparison matchers (`gt`, `gte`,
+// `lt`, `lte`). Admits only int and double so that non-numeric comparisons are
+// unrepresentable in the schema rather than rejected at compile time.
+// int and double are compared in a single numeric domain.
+message NumericValue {
+  // Exactly one must be set.
+  oneof value {
+    int64 int_value = 1;
+    double double_value = 2;
+  }
+}

--- a/proto/tero/policy/v1/trace.proto
+++ b/proto/tero/policy/v1/trace.proto
@@ -31,6 +31,9 @@ enum TraceField {
 
   // Span fields
   TRACE_FIELD_NAME = 1;
+  // trace_id, span_id, and parent_span_id are bytes. They are authored as
+  // lowercase hex and matched as raw bytes (exact/equals), or as their hex
+  // rendering for string match types.
   TRACE_FIELD_TRACE_ID = 2;
   TRACE_FIELD_SPAN_ID = 3;
   TRACE_FIELD_PARENT_SPAN_ID = 4;
@@ -106,30 +109,51 @@ message TraceMatcher {
     // Event attribute matcher (matches if span contains an event with this attribute)
     AttributePath event_attribute = 8;
 
-    // Link trace ID matcher (matches if span has a link to this trace)
+    // Link trace ID matcher (matches if span has a link to this trace).
+    // Authored as lowercase hex and decoded to bytes at policy-compile time,
+    // then compared against link trace ids as raw bytes.
     string link_trace_id = 9;
   }
 
   // Match type. Exactly one must be set.
   // Note: For span_kind and span_status fields, only exists is valid (equality is implicit).
+  //
+  // The string match types (exact, regex, starts_with, ends_with, contains)
+  // operate only on string field values. To match non-string values, use the
+  // typed equals matcher or the numeric comparison matchers (gt, gte, lt, lte).
   oneof match {
-    // Exact string match
+    // Exact string match (string field values only)
     string exact = 10;
 
-    // Regular expression match
+    // Regular expression match (string field values only)
     string regex = 11;
 
     // Field existence check
     bool exists = 12;
 
-    // Literal prefix match
+    // Literal prefix match (string field values only)
     string starts_with = 13;
 
-    // Literal suffix match
+    // Literal suffix match (string field values only)
     string ends_with = 14;
 
-    // Literal substring match
+    // Literal substring match (string field values only)
     string contains = 15;
+
+    // Typed equality for non-string field values (bool, int, double, bytes)
+    Value equals = 22;
+
+    // Numeric greater-than comparison (int/double field values)
+    NumericValue gt = 23;
+
+    // Numeric greater-than-or-equal comparison (int/double field values)
+    NumericValue gte = 24;
+
+    // Numeric less-than comparison (int/double field values)
+    NumericValue lt = 25;
+
+    // Numeric less-than-or-equal comparison (int/double field values)
+    NumericValue lte = 26;
   }
 
   // If true, inverts the match result

--- a/src/engine/compiled.rs
+++ b/src/engine/compiled.rs
@@ -10,8 +10,9 @@ use crate::error::PolicyError;
 use crate::field::{LogFieldSelector, MetricFieldSelector, TraceFieldSelector};
 use crate::proto::tero::policy::v1::{
     AggregationTemporality, LogField, LogMatcher, LogSampleKey, MetricField, MetricMatcher,
-    MetricType, SamplingMode, SpanKind, SpanStatusCode, TraceField, TraceMatcher,
-    TraceSamplingConfig, log_matcher, log_sample_key, metric_matcher, trace_matcher,
+    MetricType, NumericValue, SamplingMode, SpanKind, SpanStatusCode, TraceField, TraceMatcher,
+    TraceSamplingConfig, Value, log_matcher, log_sample_key, metric_matcher, numeric_value,
+    trace_matcher, value,
 };
 use crate::registry::PolicyStats;
 
@@ -90,6 +91,101 @@ pub struct ExistenceCheck<S: Signal> {
     pub should_exist: bool,
     /// Whether this is a negated matcher.
     pub is_negated: bool,
+}
+
+/// A compiled non-string typed value for the `equals` matcher.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CompiledValue {
+    Bool(bool),
+    Int(i64),
+    Double(f64),
+    /// Raw bytes — `hex_value` is decoded to bytes at compile time.
+    Bytes(Vec<u8>),
+}
+
+/// A compiled numeric value for `gt`/`gte`/`lt`/`lte` matchers.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CompiledNumericValue {
+    Int(i64),
+    Double(f64),
+}
+
+/// A compiled typed matcher (equals / numeric comparison).
+#[derive(Debug, Clone, PartialEq)]
+pub enum CompiledTypedMatcher {
+    Equals(CompiledValue),
+    Gt(CompiledNumericValue),
+    Gte(CompiledNumericValue),
+    Lt(CompiledNumericValue),
+    Lte(CompiledNumericValue),
+}
+
+impl CompiledTypedMatcher {
+    /// Evaluate this typed matcher against a typed field value.
+    ///
+    /// Returns `true` when the matcher fires (before applying `negate`).
+    pub fn evaluate(&self, field_value: Option<TypedValue<'_>>) -> bool {
+        let Some(fv) = field_value else {
+            return false;
+        };
+        match self {
+            CompiledTypedMatcher::Equals(expected) => match (expected, &fv) {
+                (CompiledValue::Bool(e), TypedValue::Bool(a)) => e == a,
+                // Numeric domain: int == int, double == double, cross-type promoted to double
+                (CompiledValue::Int(e), TypedValue::Int(a)) => e == a,
+                (CompiledValue::Double(e), TypedValue::Double(a)) => e == a,
+                (CompiledValue::Int(e), TypedValue::Double(a)) => (*e as f64) == *a,
+                (CompiledValue::Double(e), TypedValue::Int(a)) => *e == (*a as f64),
+                (CompiledValue::Bytes(e), TypedValue::Bytes(a)) => e.as_slice() == *a,
+                _ => false,
+            },
+            CompiledTypedMatcher::Gt(threshold) => compare_numeric(fv, threshold, |a, t| a > t),
+            CompiledTypedMatcher::Gte(threshold) => compare_numeric(fv, threshold, |a, t| a >= t),
+            CompiledTypedMatcher::Lt(threshold) => compare_numeric(fv, threshold, |a, t| a < t),
+            CompiledTypedMatcher::Lte(threshold) => compare_numeric(fv, threshold, |a, t| a <= t),
+        }
+    }
+}
+
+/// Perform a numeric comparison between a field value and a compiled threshold.
+fn compare_numeric<F: Fn(f64, f64) -> bool>(
+    fv: TypedValue<'_>,
+    threshold: &CompiledNumericValue,
+    cmp: F,
+) -> bool {
+    let field_f64 = match fv {
+        TypedValue::Int(i) => i as f64,
+        TypedValue::Double(d) => d,
+        _ => return false,
+    };
+    let threshold_f64 = match threshold {
+        CompiledNumericValue::Int(i) => *i as f64,
+        CompiledNumericValue::Double(d) => *d,
+    };
+    cmp(field_f64, threshold_f64)
+}
+
+/// Typed check for non-string matchers (equals, gt, gte, lt, lte).
+#[derive(Debug, Clone)]
+pub struct TypedCheck<S: Signal> {
+    /// Index into CompiledMatchers::policies.
+    pub policy_index: usize,
+    /// The field to read.
+    pub field: S::FieldSelector,
+    /// The compiled matcher.
+    pub matcher: CompiledTypedMatcher,
+    /// Whether this is a negated matcher.
+    pub is_negated: bool,
+}
+
+/// A typed field value returned by `Matchable::get_typed_value`.
+#[derive(Debug, Clone)]
+pub enum TypedValue<'a> {
+    String(std::borrow::Cow<'a, str>),
+    Bool(bool),
+    Int(i64),
+    Double(f64),
+    Bytes(&'a [u8]),
 }
 
 /// Pattern info for building Vectorscan databases.
@@ -287,6 +383,8 @@ pub struct CompiledMatchers<S: Signal> {
     pub databases: HashMap<MatchKey<S>, CompiledDatabase>,
     /// Existence checks that can't be compiled to Hyperscan.
     pub existence_checks: Vec<ExistenceCheck<S>>,
+    /// Typed matchers (equals, gt, gte, lt, lte) evaluated directly.
+    pub typed_checks: Vec<TypedCheck<S>>,
     /// Compiled policies indexed by position.
     pub policies: Vec<CompiledPolicy<S>>,
 }
@@ -328,6 +426,8 @@ pub struct PatternGroups<S: Signal> {
     pub groups: HashMap<MatchKey<S>, Vec<PatternInfo>>,
     /// Existence checks that can't be compiled to Hyperscan.
     pub existence_checks: Vec<ExistenceCheck<S>>,
+    /// Typed matchers (equals, gt, gte, lt, lte).
+    pub typed_checks: Vec<TypedCheck<S>>,
     /// Compiled policies.
     pub policies: Vec<CompiledPolicy<S>>,
 }
@@ -337,6 +437,7 @@ impl<S: Signal> Default for PatternGroups<S> {
         Self {
             groups: HashMap::new(),
             existence_checks: Vec::new(),
+            typed_checks: Vec::new(),
             policies: Vec::new(),
         }
     }
@@ -400,6 +501,7 @@ impl PatternGroups<LogSignal> {
                     policy_index,
                     &mut result.groups,
                     &mut result.existence_checks,
+                    &mut result.typed_checks,
                 );
             }
         }
@@ -467,6 +569,7 @@ impl PatternGroups<MetricSignal> {
                     policy_index,
                     &mut result.groups,
                     &mut result.existence_checks,
+                    &mut result.typed_checks,
                 );
             }
         }
@@ -530,6 +633,7 @@ impl PatternGroups<TraceSignal> {
                     policy_index,
                     &mut result.groups,
                     &mut result.existence_checks,
+                    &mut result.typed_checks,
                 );
             }
         }
@@ -581,6 +685,7 @@ impl<S: Signal> PatternGroups<S> {
         Ok(CompiledMatchers {
             databases,
             existence_checks: self.existence_checks,
+            typed_checks: self.typed_checks,
             policies: self.policies,
         })
     }
@@ -590,11 +695,10 @@ impl<S: Signal> PatternGroups<S> {
 // Shared match type processing
 // =============================================================================
 
-/// Process a match type and add the pattern or existence check.
+/// Process a match type and add the pattern, existence check, or typed check.
 ///
-/// This is shared across log and metric matchers since the match oneof
-/// (exact, regex, exists, starts_with, ends_with, contains) is structurally
-/// identical across signal types.
+/// This is shared across log, metric, and trace matchers since the match oneof
+/// is structurally identical across signal types.
 fn process_match_type<S: Signal, M>(
     match_type: Option<&M>,
     field: S::FieldSelector,
@@ -603,6 +707,7 @@ fn process_match_type<S: Signal, M>(
     policy_index: usize,
     groups: &mut HashMap<MatchKey<S>, Vec<PatternInfo>>,
     existence_checks: &mut Vec<ExistenceCheck<S>>,
+    typed_checks: &mut Vec<TypedCheck<S>>,
 ) where
     M: MatchTypeAccessor,
 {
@@ -661,6 +766,14 @@ fn process_match_type<S: Signal, M>(
                 case_insensitive,
             });
         }
+        MatchVariant::Typed(matcher) => {
+            typed_checks.push(TypedCheck {
+                policy_index,
+                field,
+                matcher,
+                is_negated,
+            });
+        }
     }
 }
 
@@ -672,11 +785,48 @@ enum MatchVariant<'a> {
     StartsWith(&'a str),
     EndsWith(&'a str),
     Contains(&'a str),
+    /// Typed matcher (equals/gt/gte/lt/lte) — bypasses Vectorscan.
+    Typed(CompiledTypedMatcher),
 }
 
 /// Trait for converting signal-specific match oneofs to MatchVariant.
 trait MatchTypeAccessor {
     fn as_match_variant(&self) -> MatchVariant<'_>;
+}
+
+/// Compile a proto `Value` to a `CompiledValue`, returning `None` on error.
+fn compile_value(v: &Value) -> Option<CompiledValue> {
+    match &v.value {
+        Some(value::Value::BoolValue(b)) => Some(CompiledValue::Bool(*b)),
+        Some(value::Value::IntValue(i)) => Some(CompiledValue::Int(*i)),
+        Some(value::Value::DoubleValue(d)) => Some(CompiledValue::Double(*d)),
+        Some(value::Value::BytesValue(b)) => Some(CompiledValue::Bytes(b.clone())),
+        Some(value::Value::HexValue(h)) => {
+            // Decode hex string to bytes at compile time.
+            hex_decode(h).map(CompiledValue::Bytes)
+        }
+        None => None,
+    }
+}
+
+/// Compile a proto `NumericValue` to a `CompiledNumericValue`.
+fn compile_numeric(v: &NumericValue) -> Option<CompiledNumericValue> {
+    match &v.value {
+        Some(numeric_value::Value::IntValue(i)) => Some(CompiledNumericValue::Int(*i)),
+        Some(numeric_value::Value::DoubleValue(d)) => Some(CompiledNumericValue::Double(*d)),
+        None => None,
+    }
+}
+
+/// Decode a lowercase-hex string to bytes. Returns `None` on invalid input.
+fn hex_decode(hex: &str) -> Option<Vec<u8>> {
+    if hex.len() % 2 != 0 {
+        return None;
+    }
+    (0..hex.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).ok())
+        .collect()
 }
 
 impl MatchTypeAccessor for log_matcher::Match {
@@ -688,6 +838,21 @@ impl MatchTypeAccessor for log_matcher::Match {
             log_matcher::Match::StartsWith(s) => MatchVariant::StartsWith(s),
             log_matcher::Match::EndsWith(s) => MatchVariant::EndsWith(s),
             log_matcher::Match::Contains(s) => MatchVariant::Contains(s),
+            log_matcher::Match::Equals(v) => compile_value(v)
+                .map(|cv| MatchVariant::Typed(CompiledTypedMatcher::Equals(cv)))
+                .unwrap_or(MatchVariant::Exists(false)), // invalid value → never match
+            log_matcher::Match::Gt(v) => compile_numeric(v)
+                .map(|cn| MatchVariant::Typed(CompiledTypedMatcher::Gt(cn)))
+                .unwrap_or(MatchVariant::Exists(false)),
+            log_matcher::Match::Gte(v) => compile_numeric(v)
+                .map(|cn| MatchVariant::Typed(CompiledTypedMatcher::Gte(cn)))
+                .unwrap_or(MatchVariant::Exists(false)),
+            log_matcher::Match::Lt(v) => compile_numeric(v)
+                .map(|cn| MatchVariant::Typed(CompiledTypedMatcher::Lt(cn)))
+                .unwrap_or(MatchVariant::Exists(false)),
+            log_matcher::Match::Lte(v) => compile_numeric(v)
+                .map(|cn| MatchVariant::Typed(CompiledTypedMatcher::Lte(cn)))
+                .unwrap_or(MatchVariant::Exists(false)),
         }
     }
 }
@@ -701,6 +866,21 @@ impl MatchTypeAccessor for metric_matcher::Match {
             metric_matcher::Match::StartsWith(s) => MatchVariant::StartsWith(s),
             metric_matcher::Match::EndsWith(s) => MatchVariant::EndsWith(s),
             metric_matcher::Match::Contains(s) => MatchVariant::Contains(s),
+            metric_matcher::Match::Equals(v) => compile_value(v)
+                .map(|cv| MatchVariant::Typed(CompiledTypedMatcher::Equals(cv)))
+                .unwrap_or(MatchVariant::Exists(false)),
+            metric_matcher::Match::Gt(v) => compile_numeric(v)
+                .map(|cn| MatchVariant::Typed(CompiledTypedMatcher::Gt(cn)))
+                .unwrap_or(MatchVariant::Exists(false)),
+            metric_matcher::Match::Gte(v) => compile_numeric(v)
+                .map(|cn| MatchVariant::Typed(CompiledTypedMatcher::Gte(cn)))
+                .unwrap_or(MatchVariant::Exists(false)),
+            metric_matcher::Match::Lt(v) => compile_numeric(v)
+                .map(|cn| MatchVariant::Typed(CompiledTypedMatcher::Lt(cn)))
+                .unwrap_or(MatchVariant::Exists(false)),
+            metric_matcher::Match::Lte(v) => compile_numeric(v)
+                .map(|cn| MatchVariant::Typed(CompiledTypedMatcher::Lte(cn)))
+                .unwrap_or(MatchVariant::Exists(false)),
         }
     }
 }
@@ -714,6 +894,21 @@ impl MatchTypeAccessor for trace_matcher::Match {
             trace_matcher::Match::StartsWith(s) => MatchVariant::StartsWith(s),
             trace_matcher::Match::EndsWith(s) => MatchVariant::EndsWith(s),
             trace_matcher::Match::Contains(s) => MatchVariant::Contains(s),
+            trace_matcher::Match::Equals(v) => compile_value(v)
+                .map(|cv| MatchVariant::Typed(CompiledTypedMatcher::Equals(cv)))
+                .unwrap_or(MatchVariant::Exists(false)),
+            trace_matcher::Match::Gt(v) => compile_numeric(v)
+                .map(|cn| MatchVariant::Typed(CompiledTypedMatcher::Gt(cn)))
+                .unwrap_or(MatchVariant::Exists(false)),
+            trace_matcher::Match::Gte(v) => compile_numeric(v)
+                .map(|cn| MatchVariant::Typed(CompiledTypedMatcher::Gte(cn)))
+                .unwrap_or(MatchVariant::Exists(false)),
+            trace_matcher::Match::Lt(v) => compile_numeric(v)
+                .map(|cn| MatchVariant::Typed(CompiledTypedMatcher::Lt(cn)))
+                .unwrap_or(MatchVariant::Exists(false)),
+            trace_matcher::Match::Lte(v) => compile_numeric(v)
+                .map(|cn| MatchVariant::Typed(CompiledTypedMatcher::Lte(cn)))
+                .unwrap_or(MatchVariant::Exists(false)),
         }
     }
 }

--- a/src/engine/compiled.rs
+++ b/src/engine/compiled.rs
@@ -699,6 +699,7 @@ impl<S: Signal> PatternGroups<S> {
 ///
 /// This is shared across log, metric, and trace matchers since the match oneof
 /// is structurally identical across signal types.
+#[allow(clippy::too_many_arguments)]
 fn process_match_type<S: Signal, M>(
     match_type: Option<&M>,
     field: S::FieldSelector,
@@ -820,7 +821,7 @@ fn compile_numeric(v: &NumericValue) -> Option<CompiledNumericValue> {
 
 /// Decode a lowercase-hex string to bytes. Returns `None` on invalid input.
 fn hex_decode(hex: &str) -> Option<Vec<u8>> {
-    if hex.len() % 2 != 0 {
+    if !hex.len().is_multiple_of(2) {
         return None;
     }
     (0..hex.len())

--- a/src/engine/matchable.rs
+++ b/src/engine/matchable.rs
@@ -163,7 +163,10 @@ pub trait Matchable {
     /// ```
     ///
     /// [`get_field`]: Matchable::get_field
-    fn get_typed_value(&self, field: &<Self::Signal as Signal>::FieldSelector) -> Option<TypedValue<'_>> {
+    fn get_typed_value(
+        &self,
+        field: &<Self::Signal as Signal>::FieldSelector,
+    ) -> Option<TypedValue<'_>> {
         self.get_field(field).map(TypedValue::String)
     }
 }

--- a/src/engine/matchable.rs
+++ b/src/engine/matchable.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 
+use super::compiled::TypedValue;
 use super::signal::Signal;
 
 /// Trait for types that can be matched against policies.
@@ -131,6 +132,39 @@ pub trait Matchable {
     /// that should still satisfy `exists: true` matchers.
     fn field_exists(&self, field: &<Self::Signal as Signal>::FieldSelector) -> bool {
         self.get_field(field).is_some()
+    }
+
+    /// Get a typed value for use with `equals`, `gt`, `gte`, `lt`, and `lte` matchers.
+    ///
+    /// The default implementation wraps [`get_field`] and returns the string value
+    /// as `TypedValue::String`. Override this method to expose non-string field
+    /// values (booleans, integers, floats, raw bytes) so that typed matchers
+    /// can match them.
+    ///
+    /// Return `None` when the field is absent. A present-but-wrong-type value
+    /// causes a non-match (not an error), consistent with the fail-open policy.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// fn get_typed_value(&self, field: &LogFieldSelector) -> Option<TypedValue<'_>> {
+    ///     if let LogFieldSelector::LogAttribute(path) = field {
+    ///         let key = path.first()?;
+    ///         return match self.attrs.get(key)? {
+    ///             Attr::String(s)  => Some(TypedValue::String(Cow::Borrowed(s))),
+    ///             Attr::Int(i)     => Some(TypedValue::Int(*i)),
+    ///             Attr::Double(d)  => Some(TypedValue::Double(*d)),
+    ///             Attr::Bool(b)    => Some(TypedValue::Bool(*b)),
+    ///             Attr::Bytes(bs)  => Some(TypedValue::Bytes(bs)),
+    ///         };
+    ///     }
+    ///     self.get_field(field).map(TypedValue::String)
+    /// }
+    /// ```
+    ///
+    /// [`get_field`]: Matchable::get_field
+    fn get_typed_value(&self, field: &<Self::Signal as Signal>::FieldSelector) -> Option<TypedValue<'_>> {
+        self.get_field(field).map(TypedValue::String)
     }
 }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -6169,7 +6169,11 @@ mod tests {
         let handle = registry.register_provider();
         let policy = make_policy(
             "drop-half",
-            vec![log_attr_typed_matcher("ratio", log_matcher::Match::Equals(double_value(0.5)), false)],
+            vec![log_attr_typed_matcher(
+                "ratio",
+                log_matcher::Match::Equals(double_value(0.5)),
+                false,
+            )],
             "none",
             true,
         );
@@ -6178,11 +6182,17 @@ mod tests {
         let engine = PolicyEngine::new();
 
         assert_eq!(
-            engine.evaluate(&snapshot, &TypedAttrLog::new().with_double("ratio", 0.5)).unwrap(),
-            EvaluateResult::Drop { policy_id: "drop-half".to_string() }
+            engine
+                .evaluate(&snapshot, &TypedAttrLog::new().with_double("ratio", 0.5))
+                .unwrap(),
+            EvaluateResult::Drop {
+                policy_id: "drop-half".to_string()
+            }
         );
         assert_eq!(
-            engine.evaluate(&snapshot, &TypedAttrLog::new().with_double("ratio", 0.6)).unwrap(),
+            engine
+                .evaluate(&snapshot, &TypedAttrLog::new().with_double("ratio", 0.6))
+                .unwrap(),
             EvaluateResult::NoMatch
         );
     }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -11,8 +11,9 @@ mod transform;
 mod transformable;
 
 pub use compiled::{
-    CompiledDatabase, CompiledMatchers, CompiledPolicy, CompiledSamplingMode,
-    CompiledTraceSampling, ExistenceCheck,
+    CompiledDatabase, CompiledMatchers, CompiledNumericValue, CompiledPolicy, CompiledSamplingMode,
+    CompiledTraceSampling, CompiledTypedMatcher, CompiledValue, ExistenceCheck, TypedCheck,
+    TypedValue,
 };
 pub use keep::CompiledKeep;
 pub use match_key::MatchKey;
@@ -552,6 +553,24 @@ fn find_matching_policies<S: Signal>(
 
         let exists = record.field_exists(&check.field);
         let field_matches = exists == check.should_exist;
+
+        if check.is_negated {
+            if field_matches {
+                disqualified[check.policy_index] = true;
+            }
+        } else if field_matches {
+            match_counts[check.policy_index] += 1;
+        }
+    }
+
+    // Handle typed checks (equals, gt, gte, lt, lte)
+    for check in &compiled.typed_checks {
+        if disqualified[check.policy_index] {
+            continue;
+        }
+
+        let typed_value = record.get_typed_value(&check.field);
+        let field_matches = check.matcher.evaluate(typed_value);
 
         if check.is_negated {
             if field_matches {
@@ -5821,5 +5840,274 @@ mod tests {
             Some(&"second".to_string()),
             "zzz-add-second should win because it runs last in alphanumeric order"
         );
+    }
+
+    // ==================== Typed matcher tests ====================
+
+    use crate::proto::tero::policy::v1::{NumericValue, Value, numeric_value, value};
+
+    fn log_attr_typed_matcher(
+        key: &str,
+        match_type: log_matcher::Match,
+        negate: bool,
+    ) -> LogMatcher {
+        LogMatcher {
+            field: Some(log_matcher::Field::LogAttribute(attr_path(key))),
+            r#match: Some(match_type),
+            negate,
+            case_insensitive: false,
+        }
+    }
+
+    fn int_value(i: i64) -> Value {
+        Value { value: Some(value::Value::IntValue(i)) }
+    }
+
+    fn double_value(d: f64) -> Value {
+        Value { value: Some(value::Value::DoubleValue(d)) }
+    }
+
+    fn bool_value(b: bool) -> Value {
+        Value { value: Some(value::Value::BoolValue(b)) }
+    }
+
+    fn int_numeric(i: i64) -> NumericValue {
+        NumericValue { value: Some(numeric_value::Value::IntValue(i)) }
+    }
+
+    fn double_numeric(d: f64) -> NumericValue {
+        NumericValue { value: Some(numeric_value::Value::DoubleValue(d)) }
+    }
+
+    /// A log record that supports typed (non-string) attribute values.
+    struct TypedAttrLog {
+        attrs: HashMap<String, TypedValue<'static>>,
+    }
+
+    impl TypedAttrLog {
+        fn new() -> Self { Self { attrs: HashMap::new() } }
+        fn with_int(mut self, k: &str, v: i64) -> Self {
+            self.attrs.insert(k.to_string(), TypedValue::Int(v)); self
+        }
+        fn with_double(mut self, k: &str, v: f64) -> Self {
+            self.attrs.insert(k.to_string(), TypedValue::Double(v)); self
+        }
+        fn with_bool(mut self, k: &str, v: bool) -> Self {
+            self.attrs.insert(k.to_string(), TypedValue::Bool(v)); self
+        }
+        fn with_string(mut self, k: &str, v: &'static str) -> Self {
+            self.attrs.insert(k.to_string(), TypedValue::String(std::borrow::Cow::Borrowed(v))); self
+        }
+    }
+
+    impl Matchable for TypedAttrLog {
+        type Signal = LogSignal;
+        fn get_field(&self, field: &LogFieldSelector) -> Option<std::borrow::Cow<'_, str>> {
+            match field {
+                LogFieldSelector::LogAttribute(path) => {
+                    path.first().and_then(|k| self.attrs.get(k)).and_then(|v| {
+                        if let TypedValue::String(s) = v { Some(s.clone()) } else { None }
+                    })
+                }
+                _ => None,
+            }
+        }
+        fn field_exists(&self, field: &LogFieldSelector) -> bool {
+            match field {
+                LogFieldSelector::LogAttribute(path) => {
+                    path.first().map(|k| self.attrs.contains_key(k)).unwrap_or(false)
+                }
+                _ => false,
+            }
+        }
+        fn get_typed_value(&self, field: &LogFieldSelector) -> Option<TypedValue<'_>> {
+            match field {
+                LogFieldSelector::LogAttribute(path) => {
+                    path.first().and_then(|k| self.attrs.get(k)).map(|v| match v {
+                        TypedValue::Int(i) => TypedValue::Int(*i),
+                        TypedValue::Double(d) => TypedValue::Double(*d),
+                        TypedValue::Bool(b) => TypedValue::Bool(*b),
+                        TypedValue::String(s) => TypedValue::String(s.clone()),
+                        TypedValue::Bytes(b) => TypedValue::Bytes(b),
+                    })
+                }
+                _ => None,
+            }
+        }
+    }
+
+    #[test]
+    fn typed_equals_int_matches() {
+        let registry = PolicyRegistry::new();
+        let handle = registry.register_provider();
+        let policy = make_policy(
+            "drop-200",
+            vec![log_attr_typed_matcher("status", log_matcher::Match::Equals(int_value(200)), false)],
+            "none",
+            true,
+        );
+        handle.update(vec![policy]);
+        let snapshot = registry.snapshot();
+        let engine = PolicyEngine::new();
+
+        let log = TypedAttrLog::new().with_int("status", 200);
+        assert_eq!(engine.evaluate(&snapshot, &log).unwrap(), EvaluateResult::Drop { policy_id: "drop-200".to_string() });
+
+        let log_miss = TypedAttrLog::new().with_int("status", 404);
+        assert_eq!(engine.evaluate(&snapshot, &log_miss).unwrap(), EvaluateResult::NoMatch);
+    }
+
+    #[test]
+    fn typed_equals_bool_matches() {
+        let registry = PolicyRegistry::new();
+        let handle = registry.register_provider();
+        let policy = make_policy(
+            "drop-cache-hits",
+            vec![log_attr_typed_matcher("cache.hit", log_matcher::Match::Equals(bool_value(true)), false)],
+            "none",
+            true,
+        );
+        handle.update(vec![policy]);
+        let snapshot = registry.snapshot();
+        let engine = PolicyEngine::new();
+
+        assert_eq!(
+            engine.evaluate(&snapshot, &TypedAttrLog::new().with_bool("cache.hit", true)).unwrap(),
+            EvaluateResult::Drop { policy_id: "drop-cache-hits".to_string() }
+        );
+        assert_eq!(
+            engine.evaluate(&snapshot, &TypedAttrLog::new().with_bool("cache.hit", false)).unwrap(),
+            EvaluateResult::NoMatch
+        );
+    }
+
+    #[test]
+    fn typed_gte_int_matches() {
+        let registry = PolicyRegistry::new();
+        let handle = registry.register_provider();
+        let policy = make_policy(
+            "drop-errors",
+            vec![log_attr_typed_matcher("status", log_matcher::Match::Gte(int_numeric(500)), false)],
+            "none",
+            true,
+        );
+        handle.update(vec![policy]);
+        let snapshot = registry.snapshot();
+        let engine = PolicyEngine::new();
+
+        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 500)).unwrap(),
+            EvaluateResult::Drop { policy_id: "drop-errors".to_string() });
+        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 503)).unwrap(),
+            EvaluateResult::Drop { policy_id: "drop-errors".to_string() });
+        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 499)).unwrap(),
+            EvaluateResult::NoMatch);
+    }
+
+    #[test]
+    fn typed_lt_double_matches() {
+        let registry = PolicyRegistry::new();
+        let handle = registry.register_provider();
+        let policy = make_policy(
+            "drop-fast",
+            vec![log_attr_typed_matcher("duration_s", log_matcher::Match::Lt(double_numeric(0.1)), false)],
+            "none",
+            true,
+        );
+        handle.update(vec![policy]);
+        let snapshot = registry.snapshot();
+        let engine = PolicyEngine::new();
+
+        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_double("duration_s", 0.05)).unwrap(),
+            EvaluateResult::Drop { policy_id: "drop-fast".to_string() });
+        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_double("duration_s", 0.1)).unwrap(),
+            EvaluateResult::NoMatch);
+    }
+
+    #[test]
+    fn typed_range_and_logic() {
+        // Match status >= 200 AND status < 400 (success responses)
+        let registry = PolicyRegistry::new();
+        let handle = registry.register_provider();
+        let policy = make_policy(
+            "drop-success",
+            vec![
+                log_attr_typed_matcher("status", log_matcher::Match::Gte(int_numeric(200)), false),
+                log_attr_typed_matcher("status", log_matcher::Match::Lt(int_numeric(400)), false),
+            ],
+            "none",
+            true,
+        );
+        handle.update(vec![policy]);
+        let snapshot = registry.snapshot();
+        let engine = PolicyEngine::new();
+
+        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 200)).unwrap(),
+            EvaluateResult::Drop { policy_id: "drop-success".to_string() });
+        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 301)).unwrap(),
+            EvaluateResult::Drop { policy_id: "drop-success".to_string() });
+        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 400)).unwrap(),
+            EvaluateResult::NoMatch);
+        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 500)).unwrap(),
+            EvaluateResult::NoMatch);
+    }
+
+    #[test]
+    fn typed_type_mismatch_is_nonmatch() {
+        // String value vs int matcher → non-match (not an error)
+        let registry = PolicyRegistry::new();
+        let handle = registry.register_provider();
+        let policy = make_policy(
+            "drop-200",
+            vec![log_attr_typed_matcher("status", log_matcher::Match::Equals(int_value(200)), false)],
+            "none",
+            true,
+        );
+        handle.update(vec![policy]);
+        let snapshot = registry.snapshot();
+        let engine = PolicyEngine::new();
+
+        let log = TypedAttrLog::new().with_string("status", "200");
+        assert_eq!(engine.evaluate(&snapshot, &log).unwrap(), EvaluateResult::NoMatch);
+    }
+
+    #[test]
+    fn typed_numeric_cross_domain_int_equals_double() {
+        // int_value: 5 equals double field with value 5.0 (cross-domain)
+        let registry = PolicyRegistry::new();
+        let handle = registry.register_provider();
+        let policy = make_policy(
+            "match-five",
+            vec![log_attr_typed_matcher("x", log_matcher::Match::Equals(int_value(5)), false)],
+            "all",
+            true,
+        );
+        handle.update(vec![policy]);
+        let snapshot = registry.snapshot();
+        let engine = PolicyEngine::new();
+
+        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_double("x", 5.0)).unwrap(),
+            EvaluateResult::Keep { policy_id: "match-five".to_string(), transformed: false });
+    }
+
+    #[test]
+    fn typed_negated_equals() {
+        let registry = PolicyRegistry::new();
+        let handle = registry.register_provider();
+        let policy = make_policy(
+            "drop-non-200",
+            vec![log_attr_typed_matcher("status", log_matcher::Match::Equals(int_value(200)), true)], // negated
+            "none",
+            true,
+        );
+        handle.update(vec![policy]);
+        let snapshot = registry.snapshot();
+        let engine = PolicyEngine::new();
+
+        // status=200: negated equals fires → policy is disqualified → NoMatch
+        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 200)).unwrap(),
+            EvaluateResult::NoMatch);
+        // status=500: negated equals does not fire → policy matches → Drop
+        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 500)).unwrap(),
+            EvaluateResult::Drop { policy_id: "drop-non-200".to_string() });
     }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -5860,23 +5860,33 @@ mod tests {
     }
 
     fn int_value(i: i64) -> Value {
-        Value { value: Some(value::Value::IntValue(i)) }
+        Value {
+            value: Some(value::Value::IntValue(i)),
+        }
     }
 
     fn double_value(d: f64) -> Value {
-        Value { value: Some(value::Value::DoubleValue(d)) }
+        Value {
+            value: Some(value::Value::DoubleValue(d)),
+        }
     }
 
     fn bool_value(b: bool) -> Value {
-        Value { value: Some(value::Value::BoolValue(b)) }
+        Value {
+            value: Some(value::Value::BoolValue(b)),
+        }
     }
 
     fn int_numeric(i: i64) -> NumericValue {
-        NumericValue { value: Some(numeric_value::Value::IntValue(i)) }
+        NumericValue {
+            value: Some(numeric_value::Value::IntValue(i)),
+        }
     }
 
     fn double_numeric(d: f64) -> NumericValue {
-        NumericValue { value: Some(numeric_value::Value::DoubleValue(d)) }
+        NumericValue {
+            value: Some(numeric_value::Value::DoubleValue(d)),
+        }
     }
 
     /// A log record that supports typed (non-string) attribute values.
@@ -5885,18 +5895,29 @@ mod tests {
     }
 
     impl TypedAttrLog {
-        fn new() -> Self { Self { attrs: HashMap::new() } }
+        fn new() -> Self {
+            Self {
+                attrs: HashMap::new(),
+            }
+        }
         fn with_int(mut self, k: &str, v: i64) -> Self {
-            self.attrs.insert(k.to_string(), TypedValue::Int(v)); self
+            self.attrs.insert(k.to_string(), TypedValue::Int(v));
+            self
         }
         fn with_double(mut self, k: &str, v: f64) -> Self {
-            self.attrs.insert(k.to_string(), TypedValue::Double(v)); self
+            self.attrs.insert(k.to_string(), TypedValue::Double(v));
+            self
         }
         fn with_bool(mut self, k: &str, v: bool) -> Self {
-            self.attrs.insert(k.to_string(), TypedValue::Bool(v)); self
+            self.attrs.insert(k.to_string(), TypedValue::Bool(v));
+            self
         }
         fn with_string(mut self, k: &str, v: &'static str) -> Self {
-            self.attrs.insert(k.to_string(), TypedValue::String(std::borrow::Cow::Borrowed(v))); self
+            self.attrs.insert(
+                k.to_string(),
+                TypedValue::String(std::borrow::Cow::Borrowed(v)),
+            );
+            self
         }
     }
 
@@ -5906,7 +5927,11 @@ mod tests {
             match field {
                 LogFieldSelector::LogAttribute(path) => {
                     path.first().and_then(|k| self.attrs.get(k)).and_then(|v| {
-                        if let TypedValue::String(s) = v { Some(s.clone()) } else { None }
+                        if let TypedValue::String(s) = v {
+                            Some(s.clone())
+                        } else {
+                            None
+                        }
                     })
                 }
                 _ => None,
@@ -5914,23 +5939,25 @@ mod tests {
         }
         fn field_exists(&self, field: &LogFieldSelector) -> bool {
             match field {
-                LogFieldSelector::LogAttribute(path) => {
-                    path.first().map(|k| self.attrs.contains_key(k)).unwrap_or(false)
-                }
+                LogFieldSelector::LogAttribute(path) => path
+                    .first()
+                    .map(|k| self.attrs.contains_key(k))
+                    .unwrap_or(false),
                 _ => false,
             }
         }
         fn get_typed_value(&self, field: &LogFieldSelector) -> Option<TypedValue<'_>> {
             match field {
-                LogFieldSelector::LogAttribute(path) => {
-                    path.first().and_then(|k| self.attrs.get(k)).map(|v| match v {
+                LogFieldSelector::LogAttribute(path) => path
+                    .first()
+                    .and_then(|k| self.attrs.get(k))
+                    .map(|v| match v {
                         TypedValue::Int(i) => TypedValue::Int(*i),
                         TypedValue::Double(d) => TypedValue::Double(*d),
                         TypedValue::Bool(b) => TypedValue::Bool(*b),
                         TypedValue::String(s) => TypedValue::String(s.clone()),
                         TypedValue::Bytes(b) => TypedValue::Bytes(b),
-                    })
-                }
+                    }),
                 _ => None,
             }
         }
@@ -5942,7 +5969,11 @@ mod tests {
         let handle = registry.register_provider();
         let policy = make_policy(
             "drop-200",
-            vec![log_attr_typed_matcher("status", log_matcher::Match::Equals(int_value(200)), false)],
+            vec![log_attr_typed_matcher(
+                "status",
+                log_matcher::Match::Equals(int_value(200)),
+                false,
+            )],
             "none",
             true,
         );
@@ -5951,10 +5982,18 @@ mod tests {
         let engine = PolicyEngine::new();
 
         let log = TypedAttrLog::new().with_int("status", 200);
-        assert_eq!(engine.evaluate(&snapshot, &log).unwrap(), EvaluateResult::Drop { policy_id: "drop-200".to_string() });
+        assert_eq!(
+            engine.evaluate(&snapshot, &log).unwrap(),
+            EvaluateResult::Drop {
+                policy_id: "drop-200".to_string()
+            }
+        );
 
         let log_miss = TypedAttrLog::new().with_int("status", 404);
-        assert_eq!(engine.evaluate(&snapshot, &log_miss).unwrap(), EvaluateResult::NoMatch);
+        assert_eq!(
+            engine.evaluate(&snapshot, &log_miss).unwrap(),
+            EvaluateResult::NoMatch
+        );
     }
 
     #[test]
@@ -5963,7 +6002,11 @@ mod tests {
         let handle = registry.register_provider();
         let policy = make_policy(
             "drop-cache-hits",
-            vec![log_attr_typed_matcher("cache.hit", log_matcher::Match::Equals(bool_value(true)), false)],
+            vec![log_attr_typed_matcher(
+                "cache.hit",
+                log_matcher::Match::Equals(bool_value(true)),
+                false,
+            )],
             "none",
             true,
         );
@@ -5972,11 +6015,20 @@ mod tests {
         let engine = PolicyEngine::new();
 
         assert_eq!(
-            engine.evaluate(&snapshot, &TypedAttrLog::new().with_bool("cache.hit", true)).unwrap(),
-            EvaluateResult::Drop { policy_id: "drop-cache-hits".to_string() }
+            engine
+                .evaluate(&snapshot, &TypedAttrLog::new().with_bool("cache.hit", true))
+                .unwrap(),
+            EvaluateResult::Drop {
+                policy_id: "drop-cache-hits".to_string()
+            }
         );
         assert_eq!(
-            engine.evaluate(&snapshot, &TypedAttrLog::new().with_bool("cache.hit", false)).unwrap(),
+            engine
+                .evaluate(
+                    &snapshot,
+                    &TypedAttrLog::new().with_bool("cache.hit", false)
+                )
+                .unwrap(),
             EvaluateResult::NoMatch
         );
     }
@@ -5987,7 +6039,11 @@ mod tests {
         let handle = registry.register_provider();
         let policy = make_policy(
             "drop-errors",
-            vec![log_attr_typed_matcher("status", log_matcher::Match::Gte(int_numeric(500)), false)],
+            vec![log_attr_typed_matcher(
+                "status",
+                log_matcher::Match::Gte(int_numeric(500)),
+                false,
+            )],
             "none",
             true,
         );
@@ -5995,12 +6051,28 @@ mod tests {
         let snapshot = registry.snapshot();
         let engine = PolicyEngine::new();
 
-        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 500)).unwrap(),
-            EvaluateResult::Drop { policy_id: "drop-errors".to_string() });
-        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 503)).unwrap(),
-            EvaluateResult::Drop { policy_id: "drop-errors".to_string() });
-        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 499)).unwrap(),
-            EvaluateResult::NoMatch);
+        assert_eq!(
+            engine
+                .evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 500))
+                .unwrap(),
+            EvaluateResult::Drop {
+                policy_id: "drop-errors".to_string()
+            }
+        );
+        assert_eq!(
+            engine
+                .evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 503))
+                .unwrap(),
+            EvaluateResult::Drop {
+                policy_id: "drop-errors".to_string()
+            }
+        );
+        assert_eq!(
+            engine
+                .evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 499))
+                .unwrap(),
+            EvaluateResult::NoMatch
+        );
     }
 
     #[test]
@@ -6009,7 +6081,11 @@ mod tests {
         let handle = registry.register_provider();
         let policy = make_policy(
             "drop-fast",
-            vec![log_attr_typed_matcher("duration_s", log_matcher::Match::Lt(double_numeric(0.1)), false)],
+            vec![log_attr_typed_matcher(
+                "duration_s",
+                log_matcher::Match::Lt(double_numeric(0.1)),
+                false,
+            )],
             "none",
             true,
         );
@@ -6017,10 +6093,26 @@ mod tests {
         let snapshot = registry.snapshot();
         let engine = PolicyEngine::new();
 
-        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_double("duration_s", 0.05)).unwrap(),
-            EvaluateResult::Drop { policy_id: "drop-fast".to_string() });
-        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_double("duration_s", 0.1)).unwrap(),
-            EvaluateResult::NoMatch);
+        assert_eq!(
+            engine
+                .evaluate(
+                    &snapshot,
+                    &TypedAttrLog::new().with_double("duration_s", 0.05)
+                )
+                .unwrap(),
+            EvaluateResult::Drop {
+                policy_id: "drop-fast".to_string()
+            }
+        );
+        assert_eq!(
+            engine
+                .evaluate(
+                    &snapshot,
+                    &TypedAttrLog::new().with_double("duration_s", 0.1)
+                )
+                .unwrap(),
+            EvaluateResult::NoMatch
+        );
     }
 
     #[test]
@@ -6041,14 +6133,34 @@ mod tests {
         let snapshot = registry.snapshot();
         let engine = PolicyEngine::new();
 
-        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 200)).unwrap(),
-            EvaluateResult::Drop { policy_id: "drop-success".to_string() });
-        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 301)).unwrap(),
-            EvaluateResult::Drop { policy_id: "drop-success".to_string() });
-        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 400)).unwrap(),
-            EvaluateResult::NoMatch);
-        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 500)).unwrap(),
-            EvaluateResult::NoMatch);
+        assert_eq!(
+            engine
+                .evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 200))
+                .unwrap(),
+            EvaluateResult::Drop {
+                policy_id: "drop-success".to_string()
+            }
+        );
+        assert_eq!(
+            engine
+                .evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 301))
+                .unwrap(),
+            EvaluateResult::Drop {
+                policy_id: "drop-success".to_string()
+            }
+        );
+        assert_eq!(
+            engine
+                .evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 400))
+                .unwrap(),
+            EvaluateResult::NoMatch
+        );
+        assert_eq!(
+            engine
+                .evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 500))
+                .unwrap(),
+            EvaluateResult::NoMatch
+        );
     }
 
     #[test]
@@ -6058,7 +6170,11 @@ mod tests {
         let handle = registry.register_provider();
         let policy = make_policy(
             "drop-200",
-            vec![log_attr_typed_matcher("status", log_matcher::Match::Equals(int_value(200)), false)],
+            vec![log_attr_typed_matcher(
+                "status",
+                log_matcher::Match::Equals(int_value(200)),
+                false,
+            )],
             "none",
             true,
         );
@@ -6067,7 +6183,10 @@ mod tests {
         let engine = PolicyEngine::new();
 
         let log = TypedAttrLog::new().with_string("status", "200");
-        assert_eq!(engine.evaluate(&snapshot, &log).unwrap(), EvaluateResult::NoMatch);
+        assert_eq!(
+            engine.evaluate(&snapshot, &log).unwrap(),
+            EvaluateResult::NoMatch
+        );
     }
 
     #[test]
@@ -6077,7 +6196,11 @@ mod tests {
         let handle = registry.register_provider();
         let policy = make_policy(
             "match-five",
-            vec![log_attr_typed_matcher("x", log_matcher::Match::Equals(int_value(5)), false)],
+            vec![log_attr_typed_matcher(
+                "x",
+                log_matcher::Match::Equals(int_value(5)),
+                false,
+            )],
             "all",
             true,
         );
@@ -6085,8 +6208,15 @@ mod tests {
         let snapshot = registry.snapshot();
         let engine = PolicyEngine::new();
 
-        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_double("x", 5.0)).unwrap(),
-            EvaluateResult::Keep { policy_id: "match-five".to_string(), transformed: false });
+        assert_eq!(
+            engine
+                .evaluate(&snapshot, &TypedAttrLog::new().with_double("x", 5.0))
+                .unwrap(),
+            EvaluateResult::Keep {
+                policy_id: "match-five".to_string(),
+                transformed: false
+            }
+        );
     }
 
     #[test]
@@ -6095,7 +6225,11 @@ mod tests {
         let handle = registry.register_provider();
         let policy = make_policy(
             "drop-non-200",
-            vec![log_attr_typed_matcher("status", log_matcher::Match::Equals(int_value(200)), true)], // negated
+            vec![log_attr_typed_matcher(
+                "status",
+                log_matcher::Match::Equals(int_value(200)),
+                true,
+            )], // negated
             "none",
             true,
         );
@@ -6104,10 +6238,20 @@ mod tests {
         let engine = PolicyEngine::new();
 
         // status=200: negated equals fires → policy is disqualified → NoMatch
-        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 200)).unwrap(),
-            EvaluateResult::NoMatch);
+        assert_eq!(
+            engine
+                .evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 200))
+                .unwrap(),
+            EvaluateResult::NoMatch
+        );
         // status=500: negated equals does not fire → policy matches → Drop
-        assert_eq!(engine.evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 500)).unwrap(),
-            EvaluateResult::Drop { policy_id: "drop-non-200".to_string() });
+        assert_eq!(
+            engine
+                .evaluate(&snapshot, &TypedAttrLog::new().with_int("status", 500))
+                .unwrap(),
+            EvaluateResult::Drop {
+                policy_id: "drop-non-200".to_string()
+            }
+        );
     }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -6164,6 +6164,30 @@ mod tests {
     }
 
     #[test]
+    fn typed_equals_double_matches() {
+        let registry = PolicyRegistry::new();
+        let handle = registry.register_provider();
+        let policy = make_policy(
+            "drop-half",
+            vec![log_attr_typed_matcher("ratio", log_matcher::Match::Equals(double_value(0.5)), false)],
+            "none",
+            true,
+        );
+        handle.update(vec![policy]);
+        let snapshot = registry.snapshot();
+        let engine = PolicyEngine::new();
+
+        assert_eq!(
+            engine.evaluate(&snapshot, &TypedAttrLog::new().with_double("ratio", 0.5)).unwrap(),
+            EvaluateResult::Drop { policy_id: "drop-half".to_string() }
+        );
+        assert_eq!(
+            engine.evaluate(&snapshot, &TypedAttrLog::new().with_double("ratio", 0.6)).unwrap(),
+            EvaluateResult::NoMatch
+        );
+    }
+
+    #[test]
     fn typed_type_mismatch_is_nonmatch() {
         // String value vs int matcher → non-match (not an error)
         let registry = PolicyRegistry::new();

--- a/src/proto/tero.policy.v1.rs
+++ b/src/proto/tero.policy.v1.rs
@@ -43,6 +43,67 @@ pub struct AttributePath {
     #[prost(string, repeated, tag = "1")]
     pub path: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+/// Value carries a typed, non-string scalar for the `equals` matcher. String
+/// equality is expressed with the `exact` match type, so this message
+/// intentionally has no string variant.
+///
+/// `equals` matches when the field value has the same type and value as the set
+/// variant. Integer and floating-point values are compared in a single numeric
+/// domain (an int_value may match a double field with an equal numeric value and
+/// vice versa). All other type pairings do not match.
+///
+/// Bytes are authored either as proto-native base64 (`bytes_value`) or as a
+/// lowercase-hex string (`hex_value`). The two are equivalent — hex_value is
+/// decoded to bytes at policy-compile time. A bare string literal MUST be
+/// rejected — use `exact` for strings.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Value {
+    /// Exactly one must be set.
+    #[prost(oneof = "value::Value", tags = "1, 2, 3, 4, 5")]
+    pub value: ::core::option::Option<value::Value>,
+}
+/// Nested message and enum types in `Value`.
+pub mod value {
+    /// Exactly one must be set.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Value {
+        #[prost(bool, tag = "1")]
+        BoolValue(bool),
+        #[prost(int64, tag = "2")]
+        IntValue(i64),
+        #[prost(double, tag = "3")]
+        DoubleValue(f64),
+        /// Raw bytes (base64 in proto JSON).
+        #[prost(bytes, tag = "4")]
+        BytesValue(::prost::alloc::vec::Vec<u8>),
+        /// Bytes encoded as a hexadecimal string (even length; case-insensitive on
+        /// input, canonically lowercase). Decoded to bytes at policy-compile time;
+        /// an invalid hex string MUST be rejected.
+        #[prost(string, tag = "5")]
+        HexValue(::prost::alloc::string::String),
+    }
+}
+/// NumericValue carries a typed number for the comparison matchers (`gt`, `gte`,
+/// `lt`, `lte`). Admits only int and double so that non-numeric comparisons are
+/// unrepresentable in the schema rather than rejected at compile time.
+/// int and double are compared in a single numeric domain.
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct NumericValue {
+    /// Exactly one must be set.
+    #[prost(oneof = "numeric_value::Value", tags = "1, 2")]
+    pub value: ::core::option::Option<numeric_value::Value>,
+}
+/// Nested message and enum types in `NumericValue`.
+pub mod numeric_value {
+    /// Exactly one must be set.
+    #[derive(Clone, Copy, PartialEq, ::prost::Oneof)]
+    pub enum Value {
+        #[prost(int64, tag = "1")]
+        IntValue(i64),
+        #[prost(double, tag = "2")]
+        DoubleValue(f64),
+    }
+}
 /// LogTarget defines matching and actions for logs.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LogTarget {
@@ -133,7 +194,14 @@ pub struct LogMatcher {
     #[prost(oneof = "log_matcher::Field", tags = "1, 2, 3, 4")]
     pub field: ::core::option::Option<log_matcher::Field>,
     /// Match type. Exactly one must be set.
-    #[prost(oneof = "log_matcher::Match", tags = "10, 11, 12, 13, 14, 15")]
+    ///
+    /// The string match types (exact, regex, starts_with, ends_with, contains)
+    /// operate only on string field values. To match non-string values, use the
+    /// typed equals matcher or the numeric comparison matchers (gt, gte, lt, lte).
+    #[prost(
+        oneof = "log_matcher::Match",
+        tags = "10, 11, 12, 13, 14, 15, 22, 23, 24, 25, 26"
+    )]
     pub r#match: ::core::option::Option<log_matcher::Match>,
 }
 /// Nested message and enum types in `LogMatcher`.
@@ -156,26 +224,45 @@ pub mod log_matcher {
         ScopeAttribute(super::AttributePath),
     }
     /// Match type. Exactly one must be set.
+    ///
+    /// The string match types (exact, regex, starts_with, ends_with, contains)
+    /// operate only on string field values. To match non-string values, use the
+    /// typed equals matcher or the numeric comparison matchers (gt, gte, lt, lte).
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Match {
-        /// Exact string match
+        /// Exact string match (string field values only)
         #[prost(string, tag = "10")]
         Exact(::prost::alloc::string::String),
-        /// Regular expression match
+        /// Regular expression match (string field values only)
         #[prost(string, tag = "11")]
         Regex(::prost::alloc::string::String),
         /// Field existence check
         #[prost(bool, tag = "12")]
         Exists(bool),
-        /// Literal prefix match
+        /// Literal prefix match (string field values only)
         #[prost(string, tag = "13")]
         StartsWith(::prost::alloc::string::String),
-        /// Literal suffix match
+        /// Literal suffix match (string field values only)
         #[prost(string, tag = "14")]
         EndsWith(::prost::alloc::string::String),
-        /// Literal substring match
+        /// Literal substring match (string field values only)
         #[prost(string, tag = "15")]
         Contains(::prost::alloc::string::String),
+        /// Typed equality for non-string field values (bool, int, double, bytes)
+        #[prost(message, tag = "22")]
+        Equals(super::Value),
+        /// Numeric greater-than comparison (int/double field values)
+        #[prost(message, tag = "23")]
+        Gt(super::NumericValue),
+        /// Numeric greater-than-or-equal comparison (int/double field values)
+        #[prost(message, tag = "24")]
+        Gte(super::NumericValue),
+        /// Numeric less-than comparison (int/double field values)
+        #[prost(message, tag = "25")]
+        Lt(super::NumericValue),
+        /// Numeric less-than-or-equal comparison (int/double field values)
+        #[prost(message, tag = "26")]
+        Lte(super::NumericValue),
     }
 }
 /// LogTransform defines modifications to logs.
@@ -338,6 +425,9 @@ pub enum LogField {
     /// Log record fields
     Body = 1,
     SeverityText = 2,
+    /// trace_id and span_id are bytes. They are authored as lowercase hex and
+    /// matched as raw bytes (exact/equals), or as their hex rendering for string
+    /// match types.
     TraceId = 3,
     SpanId = 4,
     EventName = 5,
@@ -412,7 +502,14 @@ pub struct MetricMatcher {
     pub field: ::core::option::Option<metric_matcher::Field>,
     /// Match type. Exactly one must be set.
     /// Note: For metric_type field, only exists is valid (type equality is implicit).
-    #[prost(oneof = "metric_matcher::Match", tags = "10, 11, 12, 13, 14, 15")]
+    ///
+    /// The string match types (exact, regex, starts_with, ends_with, contains)
+    /// operate only on string field values. To match non-string values, use the
+    /// typed equals matcher or the numeric comparison matchers (gt, gte, lt, lte).
+    #[prost(
+        oneof = "metric_matcher::Match",
+        tags = "10, 11, 12, 13, 14, 15, 22, 23, 24, 25, 26"
+    )]
     pub r#match: ::core::option::Option<metric_matcher::Match>,
 }
 /// Nested message and enum types in `MetricMatcher`.
@@ -442,26 +539,45 @@ pub mod metric_matcher {
     }
     /// Match type. Exactly one must be set.
     /// Note: For metric_type field, only exists is valid (type equality is implicit).
+    ///
+    /// The string match types (exact, regex, starts_with, ends_with, contains)
+    /// operate only on string field values. To match non-string values, use the
+    /// typed equals matcher or the numeric comparison matchers (gt, gte, lt, lte).
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Match {
-        /// Exact string match
+        /// Exact string match (string field values only)
         #[prost(string, tag = "10")]
         Exact(::prost::alloc::string::String),
-        /// Regular expression match
+        /// Regular expression match (string field values only)
         #[prost(string, tag = "11")]
         Regex(::prost::alloc::string::String),
         /// Field existence check
         #[prost(bool, tag = "12")]
         Exists(bool),
-        /// Literal prefix match
+        /// Literal prefix match (string field values only)
         #[prost(string, tag = "13")]
         StartsWith(::prost::alloc::string::String),
-        /// Literal suffix match
+        /// Literal suffix match (string field values only)
         #[prost(string, tag = "14")]
         EndsWith(::prost::alloc::string::String),
-        /// Literal substring match
+        /// Literal substring match (string field values only)
         #[prost(string, tag = "15")]
         Contains(::prost::alloc::string::String),
+        /// Typed equality for non-string field values (bool, int, double, bytes)
+        #[prost(message, tag = "22")]
+        Equals(super::Value),
+        /// Numeric greater-than comparison (int/double field values)
+        #[prost(message, tag = "23")]
+        Gt(super::NumericValue),
+        /// Numeric greater-than-or-equal comparison (int/double field values)
+        #[prost(message, tag = "24")]
+        Gte(super::NumericValue),
+        /// Numeric less-than comparison (int/double field values)
+        #[prost(message, tag = "25")]
+        Lt(super::NumericValue),
+        /// Numeric less-than-or-equal comparison (int/double field values)
+        #[prost(message, tag = "26")]
+        Lte(super::NumericValue),
     }
 }
 /// MetricField identifies simple metric fields (non-keyed).
@@ -618,7 +734,14 @@ pub struct TraceMatcher {
     pub field: ::core::option::Option<trace_matcher::Field>,
     /// Match type. Exactly one must be set.
     /// Note: For span_kind and span_status fields, only exists is valid (equality is implicit).
-    #[prost(oneof = "trace_matcher::Match", tags = "10, 11, 12, 13, 14, 15")]
+    ///
+    /// The string match types (exact, regex, starts_with, ends_with, contains)
+    /// operate only on string field values. To match non-string values, use the
+    /// typed equals matcher or the numeric comparison matchers (gt, gte, lt, lte).
+    #[prost(
+        oneof = "trace_matcher::Match",
+        tags = "10, 11, 12, 13, 14, 15, 22, 23, 24, 25, 26"
+    )]
     pub r#match: ::core::option::Option<trace_matcher::Match>,
 }
 /// Nested message and enum types in `TraceMatcher`.
@@ -651,32 +774,53 @@ pub mod trace_matcher {
         /// Event attribute matcher (matches if span contains an event with this attribute)
         #[prost(message, tag = "8")]
         EventAttribute(super::AttributePath),
-        /// Link trace ID matcher (matches if span has a link to this trace)
+        /// Link trace ID matcher (matches if span has a link to this trace).
+        /// Authored as lowercase hex and decoded to bytes at policy-compile time,
+        /// then compared against link trace ids as raw bytes.
         #[prost(string, tag = "9")]
         LinkTraceId(::prost::alloc::string::String),
     }
     /// Match type. Exactly one must be set.
     /// Note: For span_kind and span_status fields, only exists is valid (equality is implicit).
+    ///
+    /// The string match types (exact, regex, starts_with, ends_with, contains)
+    /// operate only on string field values. To match non-string values, use the
+    /// typed equals matcher or the numeric comparison matchers (gt, gte, lt, lte).
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Match {
-        /// Exact string match
+        /// Exact string match (string field values only)
         #[prost(string, tag = "10")]
         Exact(::prost::alloc::string::String),
-        /// Regular expression match
+        /// Regular expression match (string field values only)
         #[prost(string, tag = "11")]
         Regex(::prost::alloc::string::String),
         /// Field existence check
         #[prost(bool, tag = "12")]
         Exists(bool),
-        /// Literal prefix match
+        /// Literal prefix match (string field values only)
         #[prost(string, tag = "13")]
         StartsWith(::prost::alloc::string::String),
-        /// Literal suffix match
+        /// Literal suffix match (string field values only)
         #[prost(string, tag = "14")]
         EndsWith(::prost::alloc::string::String),
-        /// Literal substring match
+        /// Literal substring match (string field values only)
         #[prost(string, tag = "15")]
         Contains(::prost::alloc::string::String),
+        /// Typed equality for non-string field values (bool, int, double, bytes)
+        #[prost(message, tag = "22")]
+        Equals(super::Value),
+        /// Numeric greater-than comparison (int/double field values)
+        #[prost(message, tag = "23")]
+        Gt(super::NumericValue),
+        /// Numeric greater-than-or-equal comparison (int/double field values)
+        #[prost(message, tag = "24")]
+        Gte(super::NumericValue),
+        /// Numeric less-than comparison (int/double field values)
+        #[prost(message, tag = "25")]
+        Lt(super::NumericValue),
+        /// Numeric less-than-or-equal comparison (int/double field values)
+        #[prost(message, tag = "26")]
+        Lte(super::NumericValue),
     }
 }
 /// TraceSamplingConfig configures probabilistic sampling for traces.
@@ -729,6 +873,9 @@ pub enum TraceField {
     Unspecified = 0,
     /// Span fields
     Name = 1,
+    /// trace_id, span_id, and parent_span_id are bytes. They are authored as
+    /// lowercase hex and matched as raw bytes (exact/equals), or as their hex
+    /// rendering for string match types.
     TraceId = 2,
     SpanId = 3,
     ParentSpanId = 4,

--- a/src/proto/tero.policy.v1.serde.rs
+++ b/src/proto/tero.policy.v1.serde.rs
@@ -622,6 +622,21 @@ impl serde::Serialize for LogMatcher {
                 log_matcher::Match::Contains(v) => {
                     struct_ser.serialize_field("contains", v)?;
                 }
+                log_matcher::Match::Equals(v) => {
+                    struct_ser.serialize_field("equals", v)?;
+                }
+                log_matcher::Match::Gt(v) => {
+                    struct_ser.serialize_field("gt", v)?;
+                }
+                log_matcher::Match::Gte(v) => {
+                    struct_ser.serialize_field("gte", v)?;
+                }
+                log_matcher::Match::Lt(v) => {
+                    struct_ser.serialize_field("lt", v)?;
+                }
+                log_matcher::Match::Lte(v) => {
+                    struct_ser.serialize_field("lte", v)?;
+                }
             }
         }
         struct_ser.end()
@@ -653,6 +668,11 @@ impl<'de> serde::Deserialize<'de> for LogMatcher {
             "ends_with",
             "endsWith",
             "contains",
+            "equals",
+            "gt",
+            "gte",
+            "lt",
+            "lte",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -669,6 +689,11 @@ impl<'de> serde::Deserialize<'de> for LogMatcher {
             StartsWith,
             EndsWith,
             Contains,
+            Equals,
+            Gt,
+            Gte,
+            Lt,
+            Lte,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -702,6 +727,11 @@ impl<'de> serde::Deserialize<'de> for LogMatcher {
                             "startsWith" | "starts_with" => Ok(GeneratedField::StartsWith),
                             "endsWith" | "ends_with" => Ok(GeneratedField::EndsWith),
                             "contains" => Ok(GeneratedField::Contains),
+                            "equals" => Ok(GeneratedField::Equals),
+                            "gt" => Ok(GeneratedField::Gt),
+                            "gte" => Ok(GeneratedField::Gte),
+                            "lt" => Ok(GeneratedField::Lt),
+                            "lte" => Ok(GeneratedField::Lte),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -801,6 +831,41 @@ impl<'de> serde::Deserialize<'de> for LogMatcher {
                                 return Err(serde::de::Error::duplicate_field("contains"));
                             }
                             r#match__ = map_.next_value::<::std::option::Option<_>>()?.map(log_matcher::Match::Contains);
+                        }
+                        GeneratedField::Equals => {
+                            if r#match__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("equals"));
+                            }
+                            r#match__ = map_.next_value::<::std::option::Option<_>>()?.map(log_matcher::Match::Equals)
+;
+                        }
+                        GeneratedField::Gt => {
+                            if r#match__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("gt"));
+                            }
+                            r#match__ = map_.next_value::<::std::option::Option<_>>()?.map(log_matcher::Match::Gt)
+;
+                        }
+                        GeneratedField::Gte => {
+                            if r#match__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("gte"));
+                            }
+                            r#match__ = map_.next_value::<::std::option::Option<_>>()?.map(log_matcher::Match::Gte)
+;
+                        }
+                        GeneratedField::Lt => {
+                            if r#match__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("lt"));
+                            }
+                            r#match__ = map_.next_value::<::std::option::Option<_>>()?.map(log_matcher::Match::Lt)
+;
+                        }
+                        GeneratedField::Lte => {
+                            if r#match__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("lte"));
+                            }
+                            r#match__ = map_.next_value::<::std::option::Option<_>>()?.map(log_matcher::Match::Lte)
+;
                         }
                     }
                 }
@@ -1892,6 +1957,21 @@ impl serde::Serialize for MetricMatcher {
                 metric_matcher::Match::Contains(v) => {
                     struct_ser.serialize_field("contains", v)?;
                 }
+                metric_matcher::Match::Equals(v) => {
+                    struct_ser.serialize_field("equals", v)?;
+                }
+                metric_matcher::Match::Gt(v) => {
+                    struct_ser.serialize_field("gt", v)?;
+                }
+                metric_matcher::Match::Gte(v) => {
+                    struct_ser.serialize_field("gte", v)?;
+                }
+                metric_matcher::Match::Lt(v) => {
+                    struct_ser.serialize_field("lt", v)?;
+                }
+                metric_matcher::Match::Lte(v) => {
+                    struct_ser.serialize_field("lte", v)?;
+                }
             }
         }
         struct_ser.end()
@@ -1927,6 +2007,11 @@ impl<'de> serde::Deserialize<'de> for MetricMatcher {
             "ends_with",
             "endsWith",
             "contains",
+            "equals",
+            "gt",
+            "gte",
+            "lt",
+            "lte",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -1945,6 +2030,11 @@ impl<'de> serde::Deserialize<'de> for MetricMatcher {
             StartsWith,
             EndsWith,
             Contains,
+            Equals,
+            Gt,
+            Gte,
+            Lt,
+            Lte,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -1980,6 +2070,11 @@ impl<'de> serde::Deserialize<'de> for MetricMatcher {
                             "startsWith" | "starts_with" => Ok(GeneratedField::StartsWith),
                             "endsWith" | "ends_with" => Ok(GeneratedField::EndsWith),
                             "contains" => Ok(GeneratedField::Contains),
+                            "equals" => Ok(GeneratedField::Equals),
+                            "gt" => Ok(GeneratedField::Gt),
+                            "gte" => Ok(GeneratedField::Gte),
+                            "lt" => Ok(GeneratedField::Lt),
+                            "lte" => Ok(GeneratedField::Lte),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -2091,6 +2186,41 @@ impl<'de> serde::Deserialize<'de> for MetricMatcher {
                                 return Err(serde::de::Error::duplicate_field("contains"));
                             }
                             r#match__ = map_.next_value::<::std::option::Option<_>>()?.map(metric_matcher::Match::Contains);
+                        }
+                        GeneratedField::Equals => {
+                            if r#match__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("equals"));
+                            }
+                            r#match__ = map_.next_value::<::std::option::Option<_>>()?.map(metric_matcher::Match::Equals)
+;
+                        }
+                        GeneratedField::Gt => {
+                            if r#match__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("gt"));
+                            }
+                            r#match__ = map_.next_value::<::std::option::Option<_>>()?.map(metric_matcher::Match::Gt)
+;
+                        }
+                        GeneratedField::Gte => {
+                            if r#match__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("gte"));
+                            }
+                            r#match__ = map_.next_value::<::std::option::Option<_>>()?.map(metric_matcher::Match::Gte)
+;
+                        }
+                        GeneratedField::Lt => {
+                            if r#match__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("lt"));
+                            }
+                            r#match__ = map_.next_value::<::std::option::Option<_>>()?.map(metric_matcher::Match::Lt)
+;
+                        }
+                        GeneratedField::Lte => {
+                            if r#match__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("lte"));
+                            }
+                            r#match__ = map_.next_value::<::std::option::Option<_>>()?.map(metric_matcher::Match::Lte)
+;
                         }
                     }
                 }
@@ -2294,6 +2424,117 @@ impl<'de> serde::Deserialize<'de> for MetricType {
             }
         }
         deserializer.deserialize_any(GeneratedVisitor)
+    }
+}
+impl serde::Serialize for NumericValue {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.value.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("tero.policy.v1.NumericValue", len)?;
+        if let Some(v) = self.value.as_ref() {
+            match v {
+                numeric_value::Value::IntValue(v) => {
+                    #[allow(clippy::needless_borrow)]
+                    #[allow(clippy::needless_borrows_for_generic_args)]
+                    struct_ser.serialize_field("intValue", ToString::to_string(&v).as_str())?;
+                }
+                numeric_value::Value::DoubleValue(v) => {
+                    struct_ser.serialize_field("doubleValue", v)?;
+                }
+            }
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for NumericValue {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "int_value",
+            "intValue",
+            "double_value",
+            "doubleValue",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            IntValue,
+            DoubleValue,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "intValue" | "int_value" => Ok(GeneratedField::IntValue),
+                            "doubleValue" | "double_value" => Ok(GeneratedField::DoubleValue),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = NumericValue;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct tero.policy.v1.NumericValue")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<NumericValue, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut value__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::IntValue => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("intValue"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| numeric_value::Value::IntValue(x.0));
+                        }
+                        GeneratedField::DoubleValue => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("doubleValue"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| numeric_value::Value::DoubleValue(x.0));
+                        }
+                    }
+                }
+                Ok(NumericValue {
+                    value: value__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("tero.policy.v1.NumericValue", FIELDS, GeneratedVisitor)
     }
 }
 impl serde::Serialize for Policy {
@@ -3687,6 +3928,21 @@ impl serde::Serialize for TraceMatcher {
                 trace_matcher::Match::Contains(v) => {
                     struct_ser.serialize_field("contains", v)?;
                 }
+                trace_matcher::Match::Equals(v) => {
+                    struct_ser.serialize_field("equals", v)?;
+                }
+                trace_matcher::Match::Gt(v) => {
+                    struct_ser.serialize_field("gt", v)?;
+                }
+                trace_matcher::Match::Gte(v) => {
+                    struct_ser.serialize_field("gte", v)?;
+                }
+                trace_matcher::Match::Lt(v) => {
+                    struct_ser.serialize_field("lt", v)?;
+                }
+                trace_matcher::Match::Lte(v) => {
+                    struct_ser.serialize_field("lte", v)?;
+                }
             }
         }
         struct_ser.end()
@@ -3728,6 +3984,11 @@ impl<'de> serde::Deserialize<'de> for TraceMatcher {
             "ends_with",
             "endsWith",
             "contains",
+            "equals",
+            "gt",
+            "gte",
+            "lt",
+            "lte",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -3749,6 +4010,11 @@ impl<'de> serde::Deserialize<'de> for TraceMatcher {
             StartsWith,
             EndsWith,
             Contains,
+            Equals,
+            Gt,
+            Gte,
+            Lt,
+            Lte,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -3787,6 +4053,11 @@ impl<'de> serde::Deserialize<'de> for TraceMatcher {
                             "startsWith" | "starts_with" => Ok(GeneratedField::StartsWith),
                             "endsWith" | "ends_with" => Ok(GeneratedField::EndsWith),
                             "contains" => Ok(GeneratedField::Contains),
+                            "equals" => Ok(GeneratedField::Equals),
+                            "gt" => Ok(GeneratedField::Gt),
+                            "gte" => Ok(GeneratedField::Gte),
+                            "lt" => Ok(GeneratedField::Lt),
+                            "lte" => Ok(GeneratedField::Lte),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -3917,6 +4188,41 @@ impl<'de> serde::Deserialize<'de> for TraceMatcher {
                                 return Err(serde::de::Error::duplicate_field("contains"));
                             }
                             r#match__ = map_.next_value::<::std::option::Option<_>>()?.map(trace_matcher::Match::Contains);
+                        }
+                        GeneratedField::Equals => {
+                            if r#match__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("equals"));
+                            }
+                            r#match__ = map_.next_value::<::std::option::Option<_>>()?.map(trace_matcher::Match::Equals)
+;
+                        }
+                        GeneratedField::Gt => {
+                            if r#match__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("gt"));
+                            }
+                            r#match__ = map_.next_value::<::std::option::Option<_>>()?.map(trace_matcher::Match::Gt)
+;
+                        }
+                        GeneratedField::Gte => {
+                            if r#match__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("gte"));
+                            }
+                            r#match__ = map_.next_value::<::std::option::Option<_>>()?.map(trace_matcher::Match::Gte)
+;
+                        }
+                        GeneratedField::Lt => {
+                            if r#match__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("lt"));
+                            }
+                            r#match__ = map_.next_value::<::std::option::Option<_>>()?.map(trace_matcher::Match::Lt)
+;
+                        }
+                        GeneratedField::Lte => {
+                            if r#match__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("lte"));
+                            }
+                            r#match__ = map_.next_value::<::std::option::Option<_>>()?.map(trace_matcher::Match::Lte)
+;
                         }
                     }
                 }
@@ -4323,5 +4629,157 @@ impl<'de> serde::Deserialize<'de> for TransformStageStatus {
             }
         }
         deserializer.deserialize_struct("tero.policy.v1.TransformStageStatus", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for Value {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.value.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("tero.policy.v1.Value", len)?;
+        if let Some(v) = self.value.as_ref() {
+            match v {
+                value::Value::BoolValue(v) => {
+                    struct_ser.serialize_field("boolValue", v)?;
+                }
+                value::Value::IntValue(v) => {
+                    #[allow(clippy::needless_borrow)]
+                    #[allow(clippy::needless_borrows_for_generic_args)]
+                    struct_ser.serialize_field("intValue", ToString::to_string(&v).as_str())?;
+                }
+                value::Value::DoubleValue(v) => {
+                    struct_ser.serialize_field("doubleValue", v)?;
+                }
+                value::Value::BytesValue(v) => {
+                    #[allow(clippy::needless_borrow)]
+                    #[allow(clippy::needless_borrows_for_generic_args)]
+                    struct_ser.serialize_field("bytesValue", pbjson::private::base64::encode(&v).as_str())?;
+                }
+                value::Value::HexValue(v) => {
+                    struct_ser.serialize_field("hexValue", v)?;
+                }
+            }
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for Value {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "bool_value",
+            "boolValue",
+            "int_value",
+            "intValue",
+            "double_value",
+            "doubleValue",
+            "bytes_value",
+            "bytesValue",
+            "hex_value",
+            "hexValue",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            BoolValue,
+            IntValue,
+            DoubleValue,
+            BytesValue,
+            HexValue,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "boolValue" | "bool_value" => Ok(GeneratedField::BoolValue),
+                            "intValue" | "int_value" => Ok(GeneratedField::IntValue),
+                            "doubleValue" | "double_value" => Ok(GeneratedField::DoubleValue),
+                            "bytesValue" | "bytes_value" => Ok(GeneratedField::BytesValue),
+                            "hexValue" | "hex_value" => Ok(GeneratedField::HexValue),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Value;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct tero.policy.v1.Value")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Value, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut value__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::BoolValue => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("boolValue"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(value::Value::BoolValue);
+                        }
+                        GeneratedField::IntValue => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("intValue"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| value::Value::IntValue(x.0));
+                        }
+                        GeneratedField::DoubleValue => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("doubleValue"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| value::Value::DoubleValue(x.0));
+                        }
+                        GeneratedField::BytesValue => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("bytesValue"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<::pbjson::private::BytesDeserialize<_>>>()?.map(|x| value::Value::BytesValue(x.0));
+                        }
+                        GeneratedField::HexValue => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("hexValue"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(value::Value::HexValue);
+                        }
+                    }
+                }
+                Ok(Value {
+                    value: value__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("tero.policy.v1.Value", FIELDS, GeneratedVisitor)
     }
 }

--- a/src/provider/file.rs
+++ b/src/provider/file.rs
@@ -35,8 +35,8 @@ use serde::Deserialize;
 use crate::error::PolicyError;
 use crate::policy::Policy;
 use crate::proto::tero::policy::v1::{
-    self as pb, AttributePath, log_add, log_matcher, log_redact, log_remove, log_rename,
-    log_sample_key, metric_matcher, policy, trace_matcher,
+    self as pb, AttributePath, NumericValue, Value, log_add, log_matcher, log_redact, log_remove,
+    log_rename, log_sample_key, metric_matcher, numeric_value, policy, trace_matcher, value,
 };
 
 use super::{PolicyCallback, PolicyProvider};
@@ -529,8 +529,10 @@ struct JsonTraceSamplingConfig {
 
 // -- Shared types -------------------------------------------------------------
 
-/// Match type, shared across all signal matchers. Exactly one variant is
-/// expected per matcher object (e.g. `"regex": "error"` or `"exact": "FOO"`).
+/// Match type, shared across all signal matchers.
+///
+/// Supports shorthand scalar syntax (`gte: 500`, `equals: true`) as well as the
+/// canonical proto form (`equals: {int_value: 200}`).
 #[derive(Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum JsonMatchType {
@@ -540,6 +542,54 @@ enum JsonMatchType {
     StartsWith(String),
     EndsWith(String),
     Contains(String),
+    /// Typed equality: `equals: true`, `equals: 200`, `equals: 0.5`, or
+    /// `equals: {hex_value: "4bf9..."}`.
+    Equals(JsonValue),
+    /// Numeric greater-than: `gt: 500` or `gt: {int_value: 500}`.
+    Gt(JsonNumericValue),
+    /// Numeric greater-than-or-equal: `gte: 500`.
+    Gte(JsonNumericValue),
+    /// Numeric less-than: `lt: 0.5`.
+    Lt(JsonNumericValue),
+    /// Numeric less-than-or-equal: `lte: 1.0`.
+    Lte(JsonNumericValue),
+}
+
+/// Typed value for the `equals` matcher. Accepts scalar shorthand or canonical
+/// proto-object form.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum JsonValue {
+    Bool(bool),
+    Int(i64),
+    Double(f64),
+    Object(JsonValueObject),
+}
+
+/// Canonical proto-object form of a `Value`.
+#[derive(Deserialize)]
+struct JsonValueObject {
+    bool_value: Option<bool>,
+    int_value: Option<i64>,
+    double_value: Option<f64>,
+    hex_value: Option<String>,
+}
+
+/// Typed numeric value for comparison matchers. Accepts scalar shorthand or
+/// canonical proto-object form.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum JsonNumericValue {
+    Int(i64),
+    Double(f64),
+    Object(JsonNumericValueObject),
+}
+
+/// Canonical proto-object form of a `NumericValue`.
+#[derive(Deserialize)]
+struct JsonNumericValueObject {
+    int_value: Option<i64>,
+    double_value: Option<f64>,
 }
 
 /// Attribute path supporting three JSON representations:
@@ -946,6 +996,11 @@ impl JsonMatchType {
             Self::StartsWith(v) => log_matcher::Match::StartsWith(v),
             Self::EndsWith(v) => log_matcher::Match::EndsWith(v),
             Self::Contains(v) => log_matcher::Match::Contains(v),
+            Self::Equals(v) => log_matcher::Match::Equals(v.into_proto()),
+            Self::Gt(v) => log_matcher::Match::Gt(v.into_proto()),
+            Self::Gte(v) => log_matcher::Match::Gte(v.into_proto()),
+            Self::Lt(v) => log_matcher::Match::Lt(v.into_proto()),
+            Self::Lte(v) => log_matcher::Match::Lte(v.into_proto()),
         }
     }
 
@@ -957,6 +1012,11 @@ impl JsonMatchType {
             Self::StartsWith(v) => metric_matcher::Match::StartsWith(v),
             Self::EndsWith(v) => metric_matcher::Match::EndsWith(v),
             Self::Contains(v) => metric_matcher::Match::Contains(v),
+            Self::Equals(v) => metric_matcher::Match::Equals(v.into_proto()),
+            Self::Gt(v) => metric_matcher::Match::Gt(v.into_proto()),
+            Self::Gte(v) => metric_matcher::Match::Gte(v.into_proto()),
+            Self::Lt(v) => metric_matcher::Match::Lt(v.into_proto()),
+            Self::Lte(v) => metric_matcher::Match::Lte(v.into_proto()),
         }
     }
 
@@ -968,7 +1028,56 @@ impl JsonMatchType {
             Self::StartsWith(v) => trace_matcher::Match::StartsWith(v),
             Self::EndsWith(v) => trace_matcher::Match::EndsWith(v),
             Self::Contains(v) => trace_matcher::Match::Contains(v),
+            Self::Equals(v) => trace_matcher::Match::Equals(v.into_proto()),
+            Self::Gt(v) => trace_matcher::Match::Gt(v.into_proto()),
+            Self::Gte(v) => trace_matcher::Match::Gte(v.into_proto()),
+            Self::Lt(v) => trace_matcher::Match::Lt(v.into_proto()),
+            Self::Lte(v) => trace_matcher::Match::Lte(v.into_proto()),
         }
+    }
+}
+
+impl JsonValue {
+    fn into_proto(self) -> Value {
+        let inner = match self {
+            Self::Bool(b) => value::Value::BoolValue(b),
+            Self::Int(i) => value::Value::IntValue(i),
+            Self::Double(d) => value::Value::DoubleValue(d),
+            Self::Object(obj) => {
+                if let Some(b) = obj.bool_value {
+                    value::Value::BoolValue(b)
+                } else if let Some(i) = obj.int_value {
+                    value::Value::IntValue(i)
+                } else if let Some(d) = obj.double_value {
+                    value::Value::DoubleValue(d)
+                } else if let Some(h) = obj.hex_value {
+                    value::Value::HexValue(h)
+                } else {
+                    // Empty object — will fail at compile time (no variant set)
+                    return Value { value: None };
+                }
+            }
+        };
+        Value { value: Some(inner) }
+    }
+}
+
+impl JsonNumericValue {
+    fn into_proto(self) -> NumericValue {
+        let inner = match self {
+            Self::Int(i) => numeric_value::Value::IntValue(i),
+            Self::Double(d) => numeric_value::Value::DoubleValue(d),
+            Self::Object(obj) => {
+                if let Some(i) = obj.int_value {
+                    numeric_value::Value::IntValue(i)
+                } else if let Some(d) = obj.double_value {
+                    numeric_value::Value::DoubleValue(d)
+                } else {
+                    return NumericValue { value: None };
+                }
+            }
+        };
+        NumericValue { value: Some(inner) }
     }
 }
 
@@ -2772,6 +2881,108 @@ mod tests {
         assert!(matches!(
             metric_target.r#match[0].field,
             Some(metric_matcher::Field::AggregationTemporality(v)) if v == pb::AggregationTemporality::Delta as i32
+        ));
+    }
+
+    // ==================== Typed matcher JSON parsing tests ====================
+
+    #[test]
+    fn load_policy_with_gte_int_shorthand() {
+        let content = r#"{
+            "policies": [
+                {
+                    "id": "drop-errors",
+                    "name": "Drop HTTP errors",
+                    "log": {
+                        "match": [
+                            { "log_attribute": "http.status_code", "gte": 500 }
+                        ],
+                        "keep": "none"
+                    }
+                }
+            ]
+        }"#;
+        let file = create_temp_policy_file(content);
+        let policies = FileProvider::new(file.path()).load().unwrap();
+        let m = &policies[0].log_target().unwrap().r#match[0];
+        assert!(matches!(
+            m.r#match,
+            Some(log_matcher::Match::Gte(ref v)) if matches!(v.value, Some(pb::numeric_value::Value::IntValue(500)))
+        ));
+    }
+
+    #[test]
+    fn load_policy_with_equals_bool_shorthand() {
+        let content = r#"{
+            "policies": [
+                {
+                    "id": "drop-cache-hits",
+                    "name": "Drop cache hits",
+                    "log": {
+                        "match": [
+                            { "log_attribute": "cache.hit", "equals": true }
+                        ],
+                        "keep": "none"
+                    }
+                }
+            ]
+        }"#;
+        let file = create_temp_policy_file(content);
+        let policies = FileProvider::new(file.path()).load().unwrap();
+        let m = &policies[0].log_target().unwrap().r#match[0];
+        assert!(matches!(
+            m.r#match,
+            Some(log_matcher::Match::Equals(ref v)) if matches!(v.value, Some(pb::value::Value::BoolValue(true)))
+        ));
+    }
+
+    #[test]
+    fn load_policy_with_lt_double_shorthand() {
+        let content = r#"{
+            "policies": [
+                {
+                    "id": "drop-fast",
+                    "name": "Drop fast spans",
+                    "log": {
+                        "match": [
+                            { "log_attribute": "duration_s", "lt": 0.1 }
+                        ],
+                        "keep": "none"
+                    }
+                }
+            ]
+        }"#;
+        let file = create_temp_policy_file(content);
+        let policies = FileProvider::new(file.path()).load().unwrap();
+        let m = &policies[0].log_target().unwrap().r#match[0];
+        assert!(matches!(
+            m.r#match,
+            Some(log_matcher::Match::Lt(ref v)) if matches!(v.value, Some(pb::numeric_value::Value::DoubleValue(_)))
+        ));
+    }
+
+    #[test]
+    fn load_policy_with_equals_canonical_hex_value() {
+        let content = r#"{
+            "policies": [
+                {
+                    "id": "keep-trace",
+                    "name": "Keep trace",
+                    "log": {
+                        "match": [
+                            { "log_field": "trace_id", "equals": {"hex_value": "4bf92f3577b34da6a3ce929d0e0e4736"} }
+                        ],
+                        "keep": "all"
+                    }
+                }
+            ]
+        }"#;
+        let file = create_temp_policy_file(content);
+        let policies = FileProvider::new(file.path()).load().unwrap();
+        let m = &policies[0].log_target().unwrap().r#match[0];
+        assert!(matches!(
+            m.r#match,
+            Some(log_matcher::Match::Equals(ref v)) if matches!(&v.value, Some(pb::value::Value::HexValue(h)) if h == "4bf92f3577b34da6a3ce929d0e0e4736")
         ));
     }
 


### PR DESCRIPTION
## Summary

Upgrades `policy-rs` to match the [v1.4.0→v1.5.0 proto diff](https://github.com/usetero/policy/compare/v1.4.0...v1.5.0), adding typed equality and numeric comparison matchers to all three signal types.

### What's new

**New match types** on `LogMatcher`, `MetricMatcher`, `TraceMatcher`:

| Matcher | Type | Example |
|---------|------|---------|
| `equals` | `Value` (bool/int/double/bytes/hex) | `equals: true`, `equals: 200`, `equals: {hex_value: "4bf9..."}` |
| `gt` / `gte` / `lt` / `lte` | `NumericValue` (int/double) | `gte: 500`, `lt: 0.5` |

**New proto messages** in `shared.proto`: `Value` and `NumericValue`.

**New `Matchable::get_typed_value()` method** — default wraps `get_field` as `TypedValue::String`. Override to expose int/double/bool/bytes values for typed matchers.

### Key semantics
- Type mismatch → non-match (fail-open, never a runtime error)
- Numeric cross-domain: `int_value: 5` matches a `double` field with value `5.0`
- `hex_value` decoded to raw bytes at compile time
- `case_insensitive` has no effect on typed matchers (string-only)
- Typed checks run after Vectorscan, alongside existence checks

### JSON/YAML authoring
```json
{ "log_attribute": "http.status_code", "gte": 500 }
{ "log_attribute": "cache.hit", "equals": true }
{ "log_attribute": "duration_s", "lt": 0.1 }
{ "log_field": "trace_id", "equals": { "hex_value": "4bf92f3577b34da6a3ce929d0e0e4736" } }
```

## Test plan
- [ ] `cargo test --lib` passes (361 tests)
- [ ] Engine: `typed_equals_int_matches`, `typed_range_and_logic`, `typed_type_mismatch_is_nonmatch`, `typed_numeric_cross_domain_int_equals_double`, `typed_negated_equals`
- [ ] JSON parsing: `load_policy_with_gte_int_shorthand`, `equals_bool`, `lt_double`, `equals_canonical_hex_value`