### PR TITLE
feat: per-policy compilation errors instead of aborting batch

### DIFF
--- a/src/engine/compiled.rs
+++ b/src/engine/compiled.rs
@@ -528,7 +528,10 @@ impl PatternGroups<LogSignal> {
 
             let policy_index = result.policies.len();
             let required_match_count = log_target.r#match.iter().filter(|m| !m.negate).count();
-            let sample_key = log_target.sample_key.as_ref().and_then(extract_log_sample_key);
+            let sample_key = log_target
+                .sample_key
+                .as_ref()
+                .and_then(extract_log_sample_key);
 
             result.policies.push(CompiledPolicy {
                 id: policy.id().to_string(),
@@ -617,8 +620,7 @@ impl PatternGroups<MetricSignal> {
             }
 
             let policy_index = result.policies.len();
-            let required_match_count =
-                metric_target.r#match.iter().filter(|m| !m.negate).count();
+            let required_match_count = metric_target.r#match.iter().filter(|m| !m.negate).count();
             let keep = if metric_target.keep {
                 CompiledKeep::All
             } else {
@@ -975,8 +977,8 @@ fn validate_regex_matcher(
 /// with the compiler's error description. This is used at policy-compilation
 /// time to reject invalid patterns before they reach `hs_compile_multi`.
 fn validate_vectorscan_pattern(pattern: &str, flags: u32) -> Result<(), String> {
-    let c_pattern = CString::new(pattern)
-        .map_err(|e| format!("pattern contains null byte: {e}"))?;
+    let c_pattern =
+        CString::new(pattern).map_err(|e| format!("pattern contains null byte: {e}"))?;
     let mut db: *mut vectorscan_rs_sys::hs_database_t = ptr::null_mut();
     let mut compile_error: *mut vectorscan_rs_sys::hs_compile_error_t = ptr::null_mut();
 
@@ -1885,12 +1887,21 @@ mod tests {
         };
         let policy = Policy::new(proto);
         let stats = Arc::new(PolicyStats::default());
-        let groups =
-            PatternGroups::build_from_log_policies([(policy, stats)].into_iter()).unwrap();
-        assert!(groups.policies.is_empty(), "invalid policy should be skipped");
-        let errs = groups.compilation_errors.get("no-matchers").expect("errors collected");
+        let groups = PatternGroups::build_from_log_policies([(policy, stats)].into_iter()).unwrap();
+        assert!(
+            groups.policies.is_empty(),
+            "invalid policy should be skipped"
+        );
+        let errs = groups
+            .compilation_errors
+            .get("no-matchers")
+            .expect("errors collected");
         assert!(!errs.is_empty());
-        assert!(errs[0].contains("no matchers"), "error should mention matchers: {}", errs[0]);
+        assert!(
+            errs[0].contains("no matchers"),
+            "error should mention matchers: {}",
+            errs[0]
+        );
     }
 
     #[test]
@@ -1913,8 +1924,14 @@ mod tests {
         let stats = Arc::new(PolicyStats::default());
         let groups =
             PatternGroups::build_from_metric_policies([(policy, stats)].into_iter()).unwrap();
-        assert!(groups.policies.is_empty(), "invalid policy should be skipped");
-        let errs = groups.compilation_errors.get("metric-no-matchers").expect("errors collected");
+        assert!(
+            groups.policies.is_empty(),
+            "invalid policy should be skipped"
+        );
+        let errs = groups
+            .compilation_errors
+            .get("metric-no-matchers")
+            .expect("errors collected");
         assert!(!errs.is_empty());
     }
 
@@ -1938,7 +1955,10 @@ mod tests {
         let stats = Arc::new(PolicyStats::default());
         let groups =
             PatternGroups::build_from_trace_policies([(policy, stats)].into_iter()).unwrap();
-        assert!(groups.policies.is_empty(), "invalid policy should be skipped");
+        assert!(
+            groups.policies.is_empty(),
+            "invalid policy should be skipped"
+        );
         let errs = groups
             .compilation_errors
             .get("trace-no-matchers")
@@ -1964,8 +1984,7 @@ mod tests {
     fn invalid_log_regex_is_collected_as_error() {
         let policy = make_log_policy_with_regex("bad-regex", "([unclosed");
         let stats = Arc::new(PolicyStats::default());
-        let groups =
-            PatternGroups::build_from_log_policies([(policy, stats)].into_iter()).unwrap();
+        let groups = PatternGroups::build_from_log_policies([(policy, stats)].into_iter()).unwrap();
         assert!(groups.policies.is_empty(), "invalid policy must be skipped");
         let errs = groups
             .compilation_errors
@@ -1974,9 +1993,14 @@ mod tests {
         assert!(!errs.is_empty());
         assert!(
             errs[0].starts_with("log: match[0]: invalid regex"),
-            "error must have signal + location prefix: {}", errs[0]
+            "error must have signal + location prefix: {}",
+            errs[0]
         );
-        assert!(errs[0].contains("([unclosed"), "error must quote the pattern: {}", errs[0]);
+        assert!(
+            errs[0].contains("([unclosed"),
+            "error must quote the pattern: {}",
+            errs[0]
+        );
     }
 
     #[test]
@@ -1989,10 +2013,13 @@ mod tests {
             (bad, Arc::new(PolicyStats::default())),
             (good, Arc::new(PolicyStats::default())),
         ];
-        let compiled =
-            CompiledMatchers::<LogSignal>::build(pairs.into_iter()).unwrap();
+        let compiled = CompiledMatchers::<LogSignal>::build(pairs.into_iter()).unwrap();
 
-        assert_eq!(compiled.policies.len(), 1, "only the valid policy should compile");
+        assert_eq!(
+            compiled.policies.len(),
+            1,
+            "only the valid policy should compile"
+        );
         assert_eq!(compiled.policies[0].id, "good");
         assert!(
             compiled.compilation_errors.contains_key("bad"),
@@ -2032,15 +2059,26 @@ mod tests {
         };
         let policy = Policy::new(proto);
         let stats = Arc::new(PolicyStats::default());
-        let groups =
-            PatternGroups::build_from_log_policies([(policy, stats)].into_iter()).unwrap();
+        let groups = PatternGroups::build_from_log_policies([(policy, stats)].into_iter()).unwrap();
         let errs = groups
             .compilation_errors
             .get("multi-bad")
             .expect("errors collected");
-        assert_eq!(errs.len(), 2, "both regex errors must be collected: {errs:?}");
-        assert!(errs[0].contains("match[0]"), "first error at index 0: {}", errs[0]);
-        assert!(errs[1].contains("match[1]"), "second error at index 1: {}", errs[1]);
+        assert_eq!(
+            errs.len(),
+            2,
+            "both regex errors must be collected: {errs:?}"
+        );
+        assert!(
+            errs[0].contains("match[0]"),
+            "first error at index 0: {}",
+            errs[0]
+        );
+        assert!(
+            errs[1].contains("match[1]"),
+            "second error at index 1: {}",
+            errs[1]
+        );
     }
 
     #[test]
@@ -2053,12 +2091,21 @@ mod tests {
             "banana",
         );
         let stats = Arc::new(PolicyStats::default());
-        let groups =
-            PatternGroups::build_from_log_policies([(policy, stats)].into_iter()).unwrap();
-        assert!(groups.policies.is_empty(), "policy with bad keep must be skipped");
-        let errs = groups.compilation_errors.get("bad-keep").expect("error collected");
+        let groups = PatternGroups::build_from_log_policies([(policy, stats)].into_iter()).unwrap();
+        assert!(
+            groups.policies.is_empty(),
+            "policy with bad keep must be skipped"
+        );
+        let errs = groups
+            .compilation_errors
+            .get("bad-keep")
+            .expect("error collected");
         assert!(!errs.is_empty());
-        assert!(errs[0].starts_with("log: keep:"), "error must be prefixed: {}", errs[0]);
+        assert!(
+            errs[0].starts_with("log: keep:"),
+            "error must be prefixed: {}",
+            errs[0]
+        );
     }
 
     #[test]
@@ -2095,8 +2142,7 @@ mod tests {
         };
         let policy = Policy::new(proto);
         let stats = Arc::new(PolicyStats::default());
-        let groups =
-            PatternGroups::build_from_log_policies([(policy, stats)].into_iter()).unwrap();
+        let groups = PatternGroups::build_from_log_policies([(policy, stats)].into_iter()).unwrap();
         assert!(
             groups.policies.is_empty(),
             "policy with invalid transform must be skipped"
@@ -2108,7 +2154,8 @@ mod tests {
         assert!(!errs.is_empty());
         assert!(
             errs[0].starts_with("log: transform:"),
-            "error must be prefixed: {}", errs[0]
+            "error must be prefixed: {}",
+            errs[0]
         );
     }
 
@@ -2140,9 +2187,19 @@ mod tests {
         let stats = Arc::new(PolicyStats::default());
         let groups =
             PatternGroups::build_from_metric_policies([(policy, stats)].into_iter()).unwrap();
-        assert!(groups.policies.is_empty(), "invalid metric policy must be skipped");
-        let errs = groups.compilation_errors.get("bad-metric").expect("errors collected");
-        assert!(errs[0].starts_with("metric: match[0]: invalid regex"), "{}", errs[0]);
+        assert!(
+            groups.policies.is_empty(),
+            "invalid metric policy must be skipped"
+        );
+        let errs = groups
+            .compilation_errors
+            .get("bad-metric")
+            .expect("errors collected");
+        assert!(
+            errs[0].starts_with("metric: match[0]: invalid regex"),
+            "{}",
+            errs[0]
+        );
     }
 
     #[test]
@@ -2173,17 +2230,26 @@ mod tests {
         let stats = Arc::new(PolicyStats::default());
         let groups =
             PatternGroups::build_from_trace_policies([(policy, stats)].into_iter()).unwrap();
-        assert!(groups.policies.is_empty(), "invalid trace policy must be skipped");
-        let errs = groups.compilation_errors.get("bad-trace").expect("errors collected");
-        assert!(errs[0].starts_with("trace: match[0]: invalid regex"), "{}", errs[0]);
+        assert!(
+            groups.policies.is_empty(),
+            "invalid trace policy must be skipped"
+        );
+        let errs = groups
+            .compilation_errors
+            .get("bad-trace")
+            .expect("errors collected");
+        assert!(
+            errs[0].starts_with("trace: match[0]: invalid regex"),
+            "{}",
+            errs[0]
+        );
     }
 
     #[test]
     fn valid_regex_policy_has_no_compilation_errors() {
         let policy = make_log_policy_with_regex("ok", "error.*");
         let stats = Arc::new(PolicyStats::default());
-        let compiled =
-            CompiledMatchers::<LogSignal>::build([(policy, stats)].into_iter()).unwrap();
+        let compiled = CompiledMatchers::<LogSignal>::build([(policy, stats)].into_iter()).unwrap();
         assert_eq!(compiled.policies.len(), 1);
         assert!(compiled.compilation_errors.is_empty());
     }

--- a/src/engine/compiled.rs
+++ b/src/engine/compiled.rs
@@ -462,9 +462,8 @@ impl PatternGroups<LogSignal> {
         let mut result = PatternGroups::default();
 
         for (policy, stats) in policies {
-            let log_target = match policy.log_target() {
-                Some(t) => t,
-                None => continue,
+            let Some(log_target) = policy.log_target() else {
+                continue;
             };
 
             let mut policy_errors: Vec<String> = Vec::new();
@@ -473,38 +472,30 @@ impl PatternGroups<LogSignal> {
                 policy_errors.push("log: no matchers specified".to_string());
             }
 
-            // Validate and extract fields; collect errors without aborting.
             let mut extracted_fields: Vec<Option<LogFieldSelector>> =
                 Vec::with_capacity(log_target.r#match.len());
             for (i, matcher) in log_target.r#match.iter().enumerate() {
                 let field = match extract_log_field(matcher) {
-                    Ok(f) => {
-                        if let Some(log_matcher::Match::Regex(pattern)) = &matcher.r#match {
-                            let flags = if matcher.case_insensitive {
-                                vectorscan_rs_sys::HS_FLAG_SINGLEMATCH
-                                    | vectorscan_rs_sys::HS_FLAG_CASELESS
-                            } else {
-                                vectorscan_rs_sys::HS_FLAG_SINGLEMATCH
-                            };
-                            match validate_vectorscan_pattern(pattern, flags) {
-                                Ok(()) => Some(f),
-                                Err(msg) => {
-                                    policy_errors.push(format!(
-                                        "log: match[{i}]: invalid regex \"{pattern}\": {msg}"
-                                    ));
-                                    None
-                                }
-                            }
-                        } else {
-                            Some(f)
-                        }
-                    }
+                    Ok(f) => f,
                     Err(e) => {
                         policy_errors.push(format!("log: match[{i}]: {e}"));
-                        None
+                        extracted_fields.push(None);
+                        continue;
                     }
                 };
-                extracted_fields.push(field);
+                if let Some(log_matcher::Match::Regex(p)) = &matcher.r#match
+                    && !validate_regex_matcher(
+                        p,
+                        matcher.case_insensitive,
+                        "log",
+                        i,
+                        &mut policy_errors,
+                    )
+                {
+                    extracted_fields.push(None);
+                    continue;
+                }
+                extracted_fields.push(Some(field));
             }
 
             let keep = match CompiledKeep::parse(&log_target.keep) {
@@ -515,12 +506,12 @@ impl PatternGroups<LogSignal> {
                 }
             };
 
-            let transform_result = log_target
+            let transform = match log_target
                 .transform
                 .as_ref()
                 .map(|t| CompiledTransform::from_proto(t, policy.id()))
-                .transpose();
-            let transform = match transform_result {
+                .transpose()
+            {
                 Ok(t) => t.filter(|t| !t.is_empty()),
                 Err(e) => {
                     policy_errors.push(format!("log: transform: {e}"));
@@ -579,9 +570,8 @@ impl PatternGroups<MetricSignal> {
         let mut result = PatternGroups::default();
 
         for (policy, stats) in policies {
-            let metric_target = match policy.metric_target() {
-                Some(t) => t,
-                None => continue,
+            let Some(metric_target) = policy.metric_target() else {
+                continue;
             };
 
             let mut policy_errors: Vec<String> = Vec::new();
@@ -590,65 +580,33 @@ impl PatternGroups<MetricSignal> {
                 policy_errors.push("metric: no matchers specified".to_string());
             }
 
-            struct ExtractedMatcher {
-                field: MetricFieldSelector,
-                synthesized_match: Option<metric_matcher::Match>,
-                is_negated: bool,
-                case_insensitive: bool,
-            }
-
-            let mut extracted: Vec<Option<ExtractedMatcher>> =
+            // Extracted field info per matcher: (MetricFieldExtraction, negate, case_insensitive)
+            let mut extracted: Vec<Option<(MetricFieldExtraction, bool, bool)>> =
                 Vec::with_capacity(metric_target.r#match.len());
             for (i, matcher) in metric_target.r#match.iter().enumerate() {
-                let item = match extract_metric_field(matcher) {
-                    Ok(ext) => {
-                        let raw_pattern = ext
-                            .synthesized_match
-                            .as_ref()
-                            .or(matcher.r#match.as_ref())
-                            .and_then(|m| {
-                                if let metric_matcher::Match::Regex(p) = m {
-                                    Some(p.as_str())
-                                } else {
-                                    None
-                                }
-                            });
-                        if let Some(pattern) = raw_pattern {
-                            let flags = if matcher.case_insensitive {
-                                vectorscan_rs_sys::HS_FLAG_SINGLEMATCH
-                                    | vectorscan_rs_sys::HS_FLAG_CASELESS
-                            } else {
-                                vectorscan_rs_sys::HS_FLAG_SINGLEMATCH
-                            };
-                            match validate_vectorscan_pattern(pattern, flags) {
-                                Ok(()) => Some(ExtractedMatcher {
-                                    field: ext.field,
-                                    synthesized_match: ext.synthesized_match,
-                                    is_negated: matcher.negate,
-                                    case_insensitive: matcher.case_insensitive,
-                                }),
-                                Err(msg) => {
-                                    policy_errors.push(format!(
-                                        "metric: match[{i}]: invalid regex \"{pattern}\": {msg}"
-                                    ));
-                                    None
-                                }
-                            }
-                        } else {
-                            Some(ExtractedMatcher {
-                                field: ext.field,
-                                synthesized_match: ext.synthesized_match,
-                                is_negated: matcher.negate,
-                                case_insensitive: matcher.case_insensitive,
-                            })
-                        }
-                    }
+                let ext = match extract_metric_field(matcher) {
+                    Ok(e) => e,
                     Err(e) => {
                         policy_errors.push(format!("metric: match[{i}]: {e}"));
-                        None
+                        extracted.push(None);
+                        continue;
                     }
                 };
-                extracted.push(item);
+                // For enum fields, synthesized_match overrides the original match.
+                let effective = ext.synthesized_match.as_ref().or(matcher.r#match.as_ref());
+                if let Some(metric_matcher::Match::Regex(p)) = effective
+                    && !validate_regex_matcher(
+                        p,
+                        matcher.case_insensitive,
+                        "metric",
+                        i,
+                        &mut policy_errors,
+                    )
+                {
+                    extracted.push(None);
+                    continue;
+                }
+                extracted.push(Some((ext, matcher.negate, matcher.case_insensitive)));
             }
 
             if !policy_errors.is_empty() {
@@ -678,14 +636,14 @@ impl PatternGroups<MetricSignal> {
                 trace_sampling: None,
             });
 
-            for (matcher, ext) in metric_target.r#match.iter().zip(extracted) {
-                let ext = ext.unwrap();
+            for (matcher, item) in metric_target.r#match.iter().zip(extracted) {
+                let (ext, is_negated, case_insensitive) = item.unwrap();
                 let match_type = ext.synthesized_match.as_ref().or(matcher.r#match.as_ref());
                 process_match_type(
                     match_type,
                     ext.field,
-                    ext.is_negated,
-                    ext.case_insensitive,
+                    is_negated,
+                    case_insensitive,
                     policy_index,
                     &mut result.groups,
                     &mut result.existence_checks,
@@ -709,9 +667,8 @@ impl PatternGroups<TraceSignal> {
         let mut result = PatternGroups::default();
 
         for (policy, stats) in policies {
-            let trace_target = match policy.trace_target() {
-                Some(t) => t,
-                None => continue,
+            let Some(trace_target) = policy.trace_target() else {
+                continue;
             };
 
             let mut policy_errors: Vec<String> = Vec::new();
@@ -720,65 +677,32 @@ impl PatternGroups<TraceSignal> {
                 policy_errors.push("trace: no matchers specified".to_string());
             }
 
-            struct ExtractedMatcher {
-                field: TraceFieldSelector,
-                synthesized_match: Option<trace_matcher::Match>,
-                is_negated: bool,
-                case_insensitive: bool,
-            }
-
-            let mut extracted: Vec<Option<ExtractedMatcher>> =
+            // Extracted field info per matcher: (TraceFieldExtraction, negate, case_insensitive)
+            let mut extracted: Vec<Option<(TraceFieldExtraction, bool, bool)>> =
                 Vec::with_capacity(trace_target.r#match.len());
             for (i, matcher) in trace_target.r#match.iter().enumerate() {
-                let item = match extract_trace_field(matcher) {
-                    Ok(ext) => {
-                        let raw_pattern = ext
-                            .synthesized_match
-                            .as_ref()
-                            .or(matcher.r#match.as_ref())
-                            .and_then(|m| {
-                                if let trace_matcher::Match::Regex(p) = m {
-                                    Some(p.as_str())
-                                } else {
-                                    None
-                                }
-                            });
-                        if let Some(pattern) = raw_pattern {
-                            let flags = if matcher.case_insensitive {
-                                vectorscan_rs_sys::HS_FLAG_SINGLEMATCH
-                                    | vectorscan_rs_sys::HS_FLAG_CASELESS
-                            } else {
-                                vectorscan_rs_sys::HS_FLAG_SINGLEMATCH
-                            };
-                            match validate_vectorscan_pattern(pattern, flags) {
-                                Ok(()) => Some(ExtractedMatcher {
-                                    field: ext.field,
-                                    synthesized_match: ext.synthesized_match,
-                                    is_negated: matcher.negate,
-                                    case_insensitive: matcher.case_insensitive,
-                                }),
-                                Err(msg) => {
-                                    policy_errors.push(format!(
-                                        "trace: match[{i}]: invalid regex \"{pattern}\": {msg}"
-                                    ));
-                                    None
-                                }
-                            }
-                        } else {
-                            Some(ExtractedMatcher {
-                                field: ext.field,
-                                synthesized_match: ext.synthesized_match,
-                                is_negated: matcher.negate,
-                                case_insensitive: matcher.case_insensitive,
-                            })
-                        }
-                    }
+                let ext = match extract_trace_field(matcher) {
+                    Ok(e) => e,
                     Err(e) => {
                         policy_errors.push(format!("trace: match[{i}]: {e}"));
-                        None
+                        extracted.push(None);
+                        continue;
                     }
                 };
-                extracted.push(item);
+                let effective = ext.synthesized_match.as_ref().or(matcher.r#match.as_ref());
+                if let Some(trace_matcher::Match::Regex(p)) = effective
+                    && !validate_regex_matcher(
+                        p,
+                        matcher.case_insensitive,
+                        "trace",
+                        i,
+                        &mut policy_errors,
+                    )
+                {
+                    extracted.push(None);
+                    continue;
+                }
+                extracted.push(Some((ext, matcher.negate, matcher.case_insensitive)));
             }
 
             if !policy_errors.is_empty() {
@@ -804,14 +728,14 @@ impl PatternGroups<TraceSignal> {
                 trace_sampling: Some(trace_sampling),
             });
 
-            for (matcher, ext) in trace_target.r#match.iter().zip(extracted) {
-                let ext = ext.unwrap();
+            for (matcher, item) in trace_target.r#match.iter().zip(extracted) {
+                let (ext, is_negated, case_insensitive) = item.unwrap();
                 let match_type = ext.synthesized_match.as_ref().or(matcher.r#match.as_ref());
                 process_match_type(
                     match_type,
                     ext.field,
-                    ext.is_negated,
-                    ext.case_insensitive,
+                    is_negated,
+                    case_insensitive,
                     policy_index,
                     &mut result.groups,
                     &mut result.existence_checks,
@@ -1011,6 +935,38 @@ fn hex_decode(hex: &str) -> Option<Vec<u8>> {
         .step_by(2)
         .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).ok())
         .collect()
+}
+
+/// Compute Vectorscan compile flags for a matcher.
+fn matcher_hs_flags(case_insensitive: bool) -> u32 {
+    let mut flags = vectorscan_rs_sys::HS_FLAG_SINGLEMATCH;
+    if case_insensitive {
+        flags |= vectorscan_rs_sys::HS_FLAG_CASELESS;
+    }
+    flags
+}
+
+/// Validate a `Regex` pattern and push a located error on failure.
+///
+/// Returns `true` if the pattern is valid, `false` and appends to `errors`
+/// if not.  The error string uses the format the spec requires:
+/// `"{signal}: match[{index}]: invalid regex "...": <reason>"`.
+fn validate_regex_matcher(
+    pattern: &str,
+    case_insensitive: bool,
+    signal: &str,
+    index: usize,
+    errors: &mut Vec<String>,
+) -> bool {
+    match validate_vectorscan_pattern(pattern, matcher_hs_flags(case_insensitive)) {
+        Ok(()) => true,
+        Err(msg) => {
+            errors.push(format!(
+                "{signal}: match[{index}]: invalid regex \"{pattern}\": {msg}"
+            ));
+            false
+        }
+    }
 }
 
 /// Validate a regex pattern against the Vectorscan compiler.
@@ -1987,7 +1943,248 @@ mod tests {
             .compilation_errors
             .get("trace-no-matchers")
             .expect("errors collected");
-        assert!(!errs.is_empty(
-        ));
+        assert!(!errs.is_empty());
+    }
+
+    // =========================================================================
+    // Error handling: collection, isolation, and error string format
+    // =========================================================================
+
+    fn make_log_policy_with_regex(id: &str, regex: &str) -> Policy {
+        make_policy_with_matcher(
+            id,
+            log_matcher::Field::LogField(LogField::Body.into()),
+            log_matcher::Match::Regex(regex.to_string()),
+            false,
+            "none",
+        )
+    }
+
+    #[test]
+    fn invalid_log_regex_is_collected_as_error() {
+        let policy = make_log_policy_with_regex("bad-regex", "([unclosed");
+        let stats = Arc::new(PolicyStats::default());
+        let groups =
+            PatternGroups::build_from_log_policies([(policy, stats)].into_iter()).unwrap();
+        assert!(groups.policies.is_empty(), "invalid policy must be skipped");
+        let errs = groups
+            .compilation_errors
+            .get("bad-regex")
+            .expect("error must be recorded");
+        assert!(!errs.is_empty());
+        assert!(
+            errs[0].starts_with("log: match[0]: invalid regex"),
+            "error must have signal + location prefix: {}", errs[0]
+        );
+        assert!(errs[0].contains("([unclosed"), "error must quote the pattern: {}", errs[0]);
+    }
+
+    #[test]
+    fn valid_policy_compiles_despite_invalid_peer() {
+        // An invalid policy must NOT prevent a valid sibling from compiling.
+        let bad = make_log_policy_with_regex("bad", "([unclosed");
+        let good = make_log_policy_with_regex("good", "error.*");
+
+        let pairs = [
+            (bad, Arc::new(PolicyStats::default())),
+            (good, Arc::new(PolicyStats::default())),
+        ];
+        let compiled =
+            CompiledMatchers::<LogSignal>::build(pairs.into_iter()).unwrap();
+
+        assert_eq!(compiled.policies.len(), 1, "only the valid policy should compile");
+        assert_eq!(compiled.policies[0].id, "good");
+        assert!(
+            compiled.compilation_errors.contains_key("bad"),
+            "bad policy's error must be recorded"
+        );
+    }
+
+    #[test]
+    fn multiple_errors_in_one_policy_all_collected() {
+        // Two regex matchers both bad — both errors should appear.
+        let matcher1 = LogMatcher {
+            field: Some(log_matcher::Field::LogField(LogField::Body.into())),
+            r#match: Some(log_matcher::Match::Regex("([unclosed1".to_string())),
+            negate: false,
+            case_insensitive: false,
+        };
+        let matcher2 = LogMatcher {
+            field: Some(log_matcher::Field::LogField(LogField::SeverityText.into())),
+            r#match: Some(log_matcher::Match::Regex("([unclosed2".to_string())),
+            negate: false,
+            case_insensitive: false,
+        };
+        let log_target = LogTarget {
+            r#match: vec![matcher1, matcher2],
+            keep: "all".to_string(),
+            transform: None,
+            sample_key: None,
+        };
+        let proto = ProtoPolicy {
+            id: "multi-bad".to_string(),
+            name: "multi-bad".to_string(),
+            enabled: true,
+            target: Some(crate::proto::tero::policy::v1::policy::Target::Log(
+                log_target,
+            )),
+            ..Default::default()
+        };
+        let policy = Policy::new(proto);
+        let stats = Arc::new(PolicyStats::default());
+        let groups =
+            PatternGroups::build_from_log_policies([(policy, stats)].into_iter()).unwrap();
+        let errs = groups
+            .compilation_errors
+            .get("multi-bad")
+            .expect("errors collected");
+        assert_eq!(errs.len(), 2, "both regex errors must be collected: {errs:?}");
+        assert!(errs[0].contains("match[0]"), "first error at index 0: {}", errs[0]);
+        assert!(errs[1].contains("match[1]"), "second error at index 1: {}", errs[1]);
+    }
+
+    #[test]
+    fn invalid_keep_expression_collected_as_error() {
+        let policy = make_policy_with_matcher(
+            "bad-keep",
+            log_matcher::Field::LogField(LogField::Body.into()),
+            log_matcher::Match::Exact("ok".to_string()),
+            false,
+            "banana",
+        );
+        let stats = Arc::new(PolicyStats::default());
+        let groups =
+            PatternGroups::build_from_log_policies([(policy, stats)].into_iter()).unwrap();
+        assert!(groups.policies.is_empty(), "policy with bad keep must be skipped");
+        let errs = groups.compilation_errors.get("bad-keep").expect("error collected");
+        assert!(!errs.is_empty());
+        assert!(errs[0].starts_with("log: keep:"), "error must be prefixed: {}", errs[0]);
+    }
+
+    #[test]
+    fn invalid_transform_redact_regex_collected_as_error() {
+        use crate::proto::tero::policy::v1::{LogRedact, LogTarget, LogTransform, log_redact};
+
+        let matcher = LogMatcher {
+            field: Some(log_matcher::Field::LogField(LogField::Body.into())),
+            r#match: Some(log_matcher::Match::Exact("secret".to_string())),
+            negate: false,
+            case_insensitive: false,
+        };
+        let log_target = LogTarget {
+            r#match: vec![matcher],
+            keep: "all".to_string(),
+            transform: Some(LogTransform {
+                redact: vec![LogRedact {
+                    field: Some(log_redact::Field::LogAttribute(attr_path("password"))),
+                    replacement: "[REDACTED]".to_string(),
+                    regex: Some("([unclosed".to_string()),
+                }],
+                ..Default::default()
+            }),
+            sample_key: None,
+        };
+        let proto = ProtoPolicy {
+            id: "bad-transform".to_string(),
+            name: "bad-transform".to_string(),
+            enabled: true,
+            target: Some(crate::proto::tero::policy::v1::policy::Target::Log(
+                log_target,
+            )),
+            ..Default::default()
+        };
+        let policy = Policy::new(proto);
+        let stats = Arc::new(PolicyStats::default());
+        let groups =
+            PatternGroups::build_from_log_policies([(policy, stats)].into_iter()).unwrap();
+        assert!(
+            groups.policies.is_empty(),
+            "policy with invalid transform must be skipped"
+        );
+        let errs = groups
+            .compilation_errors
+            .get("bad-transform")
+            .expect("error collected");
+        assert!(!errs.is_empty());
+        assert!(
+            errs[0].starts_with("log: transform:"),
+            "error must be prefixed: {}", errs[0]
+        );
+    }
+
+    #[test]
+    fn invalid_metric_regex_collected() {
+        use crate::proto::tero::policy::v1::{MetricMatcher, MetricTarget, metric_matcher};
+
+        let matcher = MetricMatcher {
+            field: Some(metric_matcher::Field::MetricField(
+                crate::proto::tero::policy::v1::MetricField::Name.into(),
+            )),
+            r#match: Some(metric_matcher::Match::Regex("([bad".to_string())),
+            negate: false,
+            case_insensitive: false,
+        };
+        let proto = ProtoPolicy {
+            id: "bad-metric".to_string(),
+            name: "bad-metric".to_string(),
+            enabled: true,
+            target: Some(crate::proto::tero::policy::v1::policy::Target::Metric(
+                MetricTarget {
+                    r#match: vec![matcher],
+                    keep: true,
+                },
+            )),
+            ..Default::default()
+        };
+        let policy = Policy::new(proto);
+        let stats = Arc::new(PolicyStats::default());
+        let groups =
+            PatternGroups::build_from_metric_policies([(policy, stats)].into_iter()).unwrap();
+        assert!(groups.policies.is_empty(), "invalid metric policy must be skipped");
+        let errs = groups.compilation_errors.get("bad-metric").expect("errors collected");
+        assert!(errs[0].starts_with("metric: match[0]: invalid regex"), "{}", errs[0]);
+    }
+
+    #[test]
+    fn invalid_trace_regex_collected() {
+        use crate::proto::tero::policy::v1::{TraceMatcher, TraceTarget, trace_matcher};
+
+        let matcher = TraceMatcher {
+            field: Some(trace_matcher::Field::TraceField(
+                crate::proto::tero::policy::v1::TraceField::Name.into(),
+            )),
+            r#match: Some(trace_matcher::Match::Regex("([bad".to_string())),
+            negate: false,
+            case_insensitive: false,
+        };
+        let proto = ProtoPolicy {
+            id: "bad-trace".to_string(),
+            name: "bad-trace".to_string(),
+            enabled: true,
+            target: Some(crate::proto::tero::policy::v1::policy::Target::Trace(
+                TraceTarget {
+                    r#match: vec![matcher],
+                    keep: None,
+                },
+            )),
+            ..Default::default()
+        };
+        let policy = Policy::new(proto);
+        let stats = Arc::new(PolicyStats::default());
+        let groups =
+            PatternGroups::build_from_trace_policies([(policy, stats)].into_iter()).unwrap();
+        assert!(groups.policies.is_empty(), "invalid trace policy must be skipped");
+        let errs = groups.compilation_errors.get("bad-trace").expect("errors collected");
+        assert!(errs[0].starts_with("trace: match[0]: invalid regex"), "{}", errs[0]);
+    }
+
+    #[test]
+    fn valid_regex_policy_has_no_compilation_errors() {
+        let policy = make_log_policy_with_regex("ok", "error.*");
+        let stats = Arc::new(PolicyStats::default());
+        let compiled =
+            CompiledMatchers::<LogSignal>::build([(policy, stats)].into_iter()).unwrap();
+        assert_eq!(compiled.policies.len(), 1);
+        assert!(compiled.compilation_errors.is_empty());
     }
 }

--- a/src/engine/compiled.rs
+++ b/src/engine/compiled.rs
@@ -387,6 +387,9 @@ pub struct CompiledMatchers<S: Signal> {
     pub typed_checks: Vec<TypedCheck<S>>,
     /// Compiled policies indexed by position.
     pub policies: Vec<CompiledPolicy<S>>,
+    /// Per-policy compilation errors (policy_id → error strings).
+    /// Policies listed here were excluded from `policies` and are inert.
+    pub compilation_errors: HashMap<String, Vec<String>>,
 }
 
 impl CompiledMatchers<LogSignal> {
@@ -430,6 +433,9 @@ pub struct PatternGroups<S: Signal> {
     pub typed_checks: Vec<TypedCheck<S>>,
     /// Compiled policies.
     pub policies: Vec<CompiledPolicy<S>>,
+    /// Per-policy compilation errors (policy_id → error strings).
+    /// Policies with errors are excluded from `policies` and are inert.
+    pub compilation_errors: HashMap<String, Vec<String>>,
 }
 
 impl<S: Signal> Default for PatternGroups<S> {
@@ -439,48 +445,104 @@ impl<S: Signal> Default for PatternGroups<S> {
             existence_checks: Vec::new(),
             typed_checks: Vec::new(),
             policies: Vec::new(),
+            compilation_errors: HashMap::new(),
         }
     }
 }
 
 impl PatternGroups<LogSignal> {
     /// Build pattern groups from a list of log policies.
+    ///
+    /// Invalid policies are skipped and their errors recorded in
+    /// `compilation_errors` rather than aborting the whole batch.
+    /// Only system-level failures (e.g. OOM) return `Err`.
     pub fn build_from_log_policies(
         policies: impl Iterator<Item = (Policy, Arc<PolicyStats>)>,
     ) -> Result<Self, PolicyError> {
         let mut result = PatternGroups::default();
 
-        for (policy_index, (policy, stats)) in policies.enumerate() {
+        for (policy, stats) in policies {
             let log_target = match policy.log_target() {
                 Some(t) => t,
                 None => continue,
             };
 
+            let mut policy_errors: Vec<String> = Vec::new();
+
             if log_target.r#match.is_empty() {
-                return Err(PolicyError::InvalidPolicy {
-                    policy_id: policy.id().to_string(),
-                    reason: "log target must have at least one matcher".to_string(),
-                });
+                policy_errors.push("log: no matchers specified".to_string());
             }
 
-            let required_match_count = log_target.r#match.iter().filter(|m| !m.negate).count();
+            // Validate and extract fields; collect errors without aborting.
+            let mut extracted_fields: Vec<Option<LogFieldSelector>> =
+                Vec::with_capacity(log_target.r#match.len());
+            for (i, matcher) in log_target.r#match.iter().enumerate() {
+                let field = match extract_log_field(matcher) {
+                    Ok(f) => {
+                        if let Some(log_matcher::Match::Regex(pattern)) = &matcher.r#match {
+                            let flags = if matcher.case_insensitive {
+                                vectorscan_rs_sys::HS_FLAG_SINGLEMATCH
+                                    | vectorscan_rs_sys::HS_FLAG_CASELESS
+                            } else {
+                                vectorscan_rs_sys::HS_FLAG_SINGLEMATCH
+                            };
+                            match validate_vectorscan_pattern(pattern, flags) {
+                                Ok(()) => Some(f),
+                                Err(msg) => {
+                                    policy_errors.push(format!(
+                                        "log: match[{i}]: invalid regex \"{pattern}\": {msg}"
+                                    ));
+                                    None
+                                }
+                            }
+                        } else {
+                            Some(f)
+                        }
+                    }
+                    Err(e) => {
+                        policy_errors.push(format!("log: match[{i}]: {e}"));
+                        None
+                    }
+                };
+                extracted_fields.push(field);
+            }
 
-            let transform = log_target
+            let keep = match CompiledKeep::parse(&log_target.keep) {
+                Ok(k) => Some(k),
+                Err(e) => {
+                    policy_errors.push(format!("log: keep: {e}"));
+                    None
+                }
+            };
+
+            let transform_result = log_target
                 .transform
                 .as_ref()
                 .map(|t| CompiledTransform::from_proto(t, policy.id()))
-                .transpose()?
-                .filter(|t| !t.is_empty());
+                .transpose();
+            let transform = match transform_result {
+                Ok(t) => t.filter(|t| !t.is_empty()),
+                Err(e) => {
+                    policy_errors.push(format!("log: transform: {e}"));
+                    None
+                }
+            };
 
-            let sample_key = log_target
-                .sample_key
-                .as_ref()
-                .and_then(extract_log_sample_key);
+            if !policy_errors.is_empty() {
+                result
+                    .compilation_errors
+                    .insert(policy.id().to_string(), policy_errors);
+                continue;
+            }
+
+            let policy_index = result.policies.len();
+            let required_match_count = log_target.r#match.iter().filter(|m| !m.negate).count();
+            let sample_key = log_target.sample_key.as_ref().and_then(extract_log_sample_key);
 
             result.policies.push(CompiledPolicy {
                 id: policy.id().to_string(),
                 required_match_count,
-                keep: CompiledKeep::parse(&log_target.keep)?,
+                keep: keep.unwrap(),
                 transform,
                 stats,
                 enabled: policy.enabled(),
@@ -488,16 +550,12 @@ impl PatternGroups<LogSignal> {
                 trace_sampling: None,
             });
 
-            for matcher in &log_target.r#match {
-                let field = extract_log_field(matcher)?;
-                let is_negated = matcher.negate;
-                let case_insensitive = matcher.case_insensitive;
-
+            for (matcher, field) in log_target.r#match.iter().zip(extracted_fields) {
                 process_match_type(
                     matcher.r#match.as_ref(),
-                    field,
-                    is_negated,
-                    case_insensitive,
+                    field.unwrap(),
+                    matcher.negate,
+                    matcher.case_insensitive,
                     policy_index,
                     &mut result.groups,
                     &mut result.existence_checks,
@@ -512,26 +570,97 @@ impl PatternGroups<LogSignal> {
 
 impl PatternGroups<MetricSignal> {
     /// Build pattern groups from a list of metric policies.
+    ///
+    /// Invalid policies are skipped and their errors recorded in
+    /// `compilation_errors` rather than aborting the whole batch.
     pub fn build_from_metric_policies(
         policies: impl Iterator<Item = (Policy, Arc<PolicyStats>)>,
     ) -> Result<Self, PolicyError> {
         let mut result = PatternGroups::default();
 
-        for (policy_index, (policy, stats)) in policies.enumerate() {
+        for (policy, stats) in policies {
             let metric_target = match policy.metric_target() {
                 Some(t) => t,
                 None => continue,
             };
 
+            let mut policy_errors: Vec<String> = Vec::new();
+
             if metric_target.r#match.is_empty() {
-                return Err(PolicyError::InvalidPolicy {
-                    policy_id: policy.id().to_string(),
-                    reason: "metric target must have at least one matcher".to_string(),
-                });
+                policy_errors.push("metric: no matchers specified".to_string());
             }
 
-            let required_match_count = metric_target.r#match.iter().filter(|m| !m.negate).count();
+            struct ExtractedMatcher {
+                field: MetricFieldSelector,
+                synthesized_match: Option<metric_matcher::Match>,
+                is_negated: bool,
+                case_insensitive: bool,
+            }
 
+            let mut extracted: Vec<Option<ExtractedMatcher>> =
+                Vec::with_capacity(metric_target.r#match.len());
+            for (i, matcher) in metric_target.r#match.iter().enumerate() {
+                let item = match extract_metric_field(matcher) {
+                    Ok(ext) => {
+                        let raw_pattern = ext
+                            .synthesized_match
+                            .as_ref()
+                            .or(matcher.r#match.as_ref())
+                            .and_then(|m| {
+                                if let metric_matcher::Match::Regex(p) = m {
+                                    Some(p.as_str())
+                                } else {
+                                    None
+                                }
+                            });
+                        if let Some(pattern) = raw_pattern {
+                            let flags = if matcher.case_insensitive {
+                                vectorscan_rs_sys::HS_FLAG_SINGLEMATCH
+                                    | vectorscan_rs_sys::HS_FLAG_CASELESS
+                            } else {
+                                vectorscan_rs_sys::HS_FLAG_SINGLEMATCH
+                            };
+                            match validate_vectorscan_pattern(pattern, flags) {
+                                Ok(()) => Some(ExtractedMatcher {
+                                    field: ext.field,
+                                    synthesized_match: ext.synthesized_match,
+                                    is_negated: matcher.negate,
+                                    case_insensitive: matcher.case_insensitive,
+                                }),
+                                Err(msg) => {
+                                    policy_errors.push(format!(
+                                        "metric: match[{i}]: invalid regex \"{pattern}\": {msg}"
+                                    ));
+                                    None
+                                }
+                            }
+                        } else {
+                            Some(ExtractedMatcher {
+                                field: ext.field,
+                                synthesized_match: ext.synthesized_match,
+                                is_negated: matcher.negate,
+                                case_insensitive: matcher.case_insensitive,
+                            })
+                        }
+                    }
+                    Err(e) => {
+                        policy_errors.push(format!("metric: match[{i}]: {e}"));
+                        None
+                    }
+                };
+                extracted.push(item);
+            }
+
+            if !policy_errors.is_empty() {
+                result
+                    .compilation_errors
+                    .insert(policy.id().to_string(), policy_errors);
+                continue;
+            }
+
+            let policy_index = result.policies.len();
+            let required_match_count =
+                metric_target.r#match.iter().filter(|m| !m.negate).count();
             let keep = if metric_target.keep {
                 CompiledKeep::All
             } else {
@@ -549,23 +678,14 @@ impl PatternGroups<MetricSignal> {
                 trace_sampling: None,
             });
 
-            for matcher in &metric_target.r#match {
-                let is_negated = matcher.negate;
-                let case_insensitive = matcher.case_insensitive;
-
-                let extraction = extract_metric_field(matcher)?;
-
-                // Use synthesized match for enum fields, otherwise use the matcher's match.
-                let match_type = extraction
-                    .synthesized_match
-                    .as_ref()
-                    .or(matcher.r#match.as_ref());
-
+            for (matcher, ext) in metric_target.r#match.iter().zip(extracted) {
+                let ext = ext.unwrap();
+                let match_type = ext.synthesized_match.as_ref().or(matcher.r#match.as_ref());
                 process_match_type(
                     match_type,
-                    extraction.field,
-                    is_negated,
-                    case_insensitive,
+                    ext.field,
+                    ext.is_negated,
+                    ext.case_insensitive,
                     policy_index,
                     &mut result.groups,
                     &mut result.existence_checks,
@@ -580,26 +700,96 @@ impl PatternGroups<MetricSignal> {
 
 impl PatternGroups<TraceSignal> {
     /// Build pattern groups from a list of trace policies.
+    ///
+    /// Invalid policies are skipped and their errors recorded in
+    /// `compilation_errors` rather than aborting the whole batch.
     pub fn build_from_trace_policies(
         policies: impl Iterator<Item = (Policy, Arc<PolicyStats>)>,
     ) -> Result<Self, PolicyError> {
         let mut result = PatternGroups::default();
 
-        for (policy_index, (policy, stats)) in policies.enumerate() {
+        for (policy, stats) in policies {
             let trace_target = match policy.trace_target() {
                 Some(t) => t,
                 None => continue,
             };
 
+            let mut policy_errors: Vec<String> = Vec::new();
+
             if trace_target.r#match.is_empty() {
-                return Err(PolicyError::InvalidPolicy {
-                    policy_id: policy.id().to_string(),
-                    reason: "trace target must have at least one matcher".to_string(),
-                });
+                policy_errors.push("trace: no matchers specified".to_string());
             }
 
-            let required_match_count = trace_target.r#match.iter().filter(|m| !m.negate).count();
+            struct ExtractedMatcher {
+                field: TraceFieldSelector,
+                synthesized_match: Option<trace_matcher::Match>,
+                is_negated: bool,
+                case_insensitive: bool,
+            }
 
+            let mut extracted: Vec<Option<ExtractedMatcher>> =
+                Vec::with_capacity(trace_target.r#match.len());
+            for (i, matcher) in trace_target.r#match.iter().enumerate() {
+                let item = match extract_trace_field(matcher) {
+                    Ok(ext) => {
+                        let raw_pattern = ext
+                            .synthesized_match
+                            .as_ref()
+                            .or(matcher.r#match.as_ref())
+                            .and_then(|m| {
+                                if let trace_matcher::Match::Regex(p) = m {
+                                    Some(p.as_str())
+                                } else {
+                                    None
+                                }
+                            });
+                        if let Some(pattern) = raw_pattern {
+                            let flags = if matcher.case_insensitive {
+                                vectorscan_rs_sys::HS_FLAG_SINGLEMATCH
+                                    | vectorscan_rs_sys::HS_FLAG_CASELESS
+                            } else {
+                                vectorscan_rs_sys::HS_FLAG_SINGLEMATCH
+                            };
+                            match validate_vectorscan_pattern(pattern, flags) {
+                                Ok(()) => Some(ExtractedMatcher {
+                                    field: ext.field,
+                                    synthesized_match: ext.synthesized_match,
+                                    is_negated: matcher.negate,
+                                    case_insensitive: matcher.case_insensitive,
+                                }),
+                                Err(msg) => {
+                                    policy_errors.push(format!(
+                                        "trace: match[{i}]: invalid regex \"{pattern}\": {msg}"
+                                    ));
+                                    None
+                                }
+                            }
+                        } else {
+                            Some(ExtractedMatcher {
+                                field: ext.field,
+                                synthesized_match: ext.synthesized_match,
+                                is_negated: matcher.negate,
+                                case_insensitive: matcher.case_insensitive,
+                            })
+                        }
+                    }
+                    Err(e) => {
+                        policy_errors.push(format!("trace: match[{i}]: {e}"));
+                        None
+                    }
+                };
+                extracted.push(item);
+            }
+
+            if !policy_errors.is_empty() {
+                result
+                    .compilation_errors
+                    .insert(policy.id().to_string(), policy_errors);
+                continue;
+            }
+
+            let policy_index = result.policies.len();
+            let required_match_count = trace_target.r#match.iter().filter(|m| !m.negate).count();
             let keep = compile_trace_keep(trace_target.keep.as_ref());
             let trace_sampling = compile_trace_sampling(trace_target.keep.as_ref());
 
@@ -614,22 +804,14 @@ impl PatternGroups<TraceSignal> {
                 trace_sampling: Some(trace_sampling),
             });
 
-            for matcher in &trace_target.r#match {
-                let is_negated = matcher.negate;
-                let case_insensitive = matcher.case_insensitive;
-
-                let extraction = extract_trace_field(matcher)?;
-
-                let match_type = extraction
-                    .synthesized_match
-                    .as_ref()
-                    .or(matcher.r#match.as_ref());
-
+            for (matcher, ext) in trace_target.r#match.iter().zip(extracted) {
+                let ext = ext.unwrap();
+                let match_type = ext.synthesized_match.as_ref().or(matcher.r#match.as_ref());
                 process_match_type(
                     match_type,
-                    extraction.field,
-                    is_negated,
-                    case_insensitive,
+                    ext.field,
+                    ext.is_negated,
+                    ext.case_insensitive,
                     policy_index,
                     &mut result.groups,
                     &mut result.existence_checks,
@@ -687,6 +869,7 @@ impl<S: Signal> PatternGroups<S> {
             existence_checks: self.existence_checks,
             typed_checks: self.typed_checks,
             policies: self.policies,
+            compilation_errors: self.compilation_errors,
         })
     }
 }
@@ -828,6 +1011,52 @@ fn hex_decode(hex: &str) -> Option<Vec<u8>> {
         .step_by(2)
         .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).ok())
         .collect()
+}
+
+/// Validate a regex pattern against the Vectorscan compiler.
+///
+/// Returns `Ok(())` if the pattern compiles successfully, or `Err(message)`
+/// with the compiler's error description. This is used at policy-compilation
+/// time to reject invalid patterns before they reach `hs_compile_multi`.
+fn validate_vectorscan_pattern(pattern: &str, flags: u32) -> Result<(), String> {
+    let c_pattern = CString::new(pattern)
+        .map_err(|e| format!("pattern contains null byte: {e}"))?;
+    let mut db: *mut vectorscan_rs_sys::hs_database_t = ptr::null_mut();
+    let mut compile_error: *mut vectorscan_rs_sys::hs_compile_error_t = ptr::null_mut();
+
+    let result = unsafe {
+        vectorscan_rs_sys::hs_compile(
+            c_pattern.as_ptr(),
+            flags,
+            vectorscan_rs_sys::HS_MODE_BLOCK,
+            ptr::null(),
+            &mut db,
+            &mut compile_error,
+        )
+    };
+
+    if result == vectorscan_rs_sys::HS_SUCCESS as i32 {
+        unsafe { vectorscan_rs_sys::hs_free_database(db) };
+        Ok(())
+    } else {
+        let msg = if !compile_error.is_null() {
+            let s = unsafe {
+                let msg_ptr = (*compile_error).message;
+                if msg_ptr.is_null() {
+                    "unknown error".to_string()
+                } else {
+                    std::ffi::CStr::from_ptr(msg_ptr)
+                        .to_string_lossy()
+                        .into_owned()
+                }
+            };
+            unsafe { vectorscan_rs_sys::hs_free_compile_error(compile_error) };
+            s
+        } else {
+            format!("compile failed with code {result}")
+        };
+        Err(msg)
+    }
 }
 
 impl MatchTypeAccessor for log_matcher::Match {
@@ -1682,7 +1911,7 @@ mod tests {
     }
 
     #[test]
-    fn build_from_log_policies_empty_match_list_rejected() {
+    fn build_from_log_policies_empty_match_list_collected() {
         let log_target = LogTarget {
             r#match: Vec::new(),
             keep: "all".to_string(),
@@ -1700,16 +1929,16 @@ mod tests {
         };
         let policy = Policy::new(proto);
         let stats = Arc::new(PolicyStats::default());
-        let err =
-            PatternGroups::build_from_log_policies([(policy, stats)].into_iter()).unwrap_err();
-        assert!(matches!(
-            err,
-            PolicyError::InvalidPolicy { ref policy_id, .. } if policy_id == "no-matchers"
-        ));
+        let groups =
+            PatternGroups::build_from_log_policies([(policy, stats)].into_iter()).unwrap();
+        assert!(groups.policies.is_empty(), "invalid policy should be skipped");
+        let errs = groups.compilation_errors.get("no-matchers").expect("errors collected");
+        assert!(!errs.is_empty());
+        assert!(errs[0].contains("no matchers"), "error should mention matchers: {}", errs[0]);
     }
 
     #[test]
-    fn build_from_metric_policies_empty_match_list_rejected() {
+    fn build_from_metric_policies_empty_match_list_collected() {
         use crate::proto::tero::policy::v1::MetricTarget;
         let metric_target = MetricTarget {
             r#match: Vec::new(),
@@ -1726,16 +1955,15 @@ mod tests {
         };
         let policy = Policy::new(proto);
         let stats = Arc::new(PolicyStats::default());
-        let err =
-            PatternGroups::build_from_metric_policies([(policy, stats)].into_iter()).unwrap_err();
-        assert!(matches!(
-            err,
-            PolicyError::InvalidPolicy { ref policy_id, .. } if policy_id == "metric-no-matchers"
-        ));
+        let groups =
+            PatternGroups::build_from_metric_policies([(policy, stats)].into_iter()).unwrap();
+        assert!(groups.policies.is_empty(), "invalid policy should be skipped");
+        let errs = groups.compilation_errors.get("metric-no-matchers").expect("errors collected");
+        assert!(!errs.is_empty());
     }
 
     #[test]
-    fn build_from_trace_policies_empty_match_list_rejected() {
+    fn build_from_trace_policies_empty_match_list_collected() {
         use crate::proto::tero::policy::v1::TraceTarget;
         let trace_target = TraceTarget {
             r#match: Vec::new(),
@@ -1752,11 +1980,14 @@ mod tests {
         };
         let policy = Policy::new(proto);
         let stats = Arc::new(PolicyStats::default());
-        let err =
-            PatternGroups::build_from_trace_policies([(policy, stats)].into_iter()).unwrap_err();
-        assert!(matches!(
-            err,
-            PolicyError::InvalidPolicy { ref policy_id, .. } if policy_id == "trace-no-matchers"
+        let groups =
+            PatternGroups::build_from_trace_policies([(policy, stats)].into_iter()).unwrap();
+        assert!(groups.policies.is_empty(), "invalid policy should be skipped");
+        let errs = groups
+            .compilation_errors
+            .get("trace-no-matchers")
+            .expect("errors collected");
+        assert!(!errs.is_empty(
         ));
     }
 }

--- a/src/provider/sync.rs
+++ b/src/provider/sync.rs
@@ -11,7 +11,7 @@ pub fn stats_to_sync_status(id: String, stats: PolicyStatsSnapshot) -> PolicySyn
         id,
         match_hits: stats.match_hits as i64,
         match_misses: stats.match_misses as i64,
-        errors: vec![],
+        errors: stats.compilation_errors,
         remove: Some(TransformStageStatus {
             hits: stats.remove.0 as i64,
             misses: stats.remove.1 as i64,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -101,6 +101,9 @@ impl PolicyStats {
     }
 
     /// Reset all stats (match + transform stages) and return previous values.
+    ///
+    /// `compilation_errors` is always empty here; the registry's stats collector
+    /// fills it in from the snapshot after calling this method.
     pub fn reset_all(&self) -> PolicyStatsSnapshot {
         PolicyStatsSnapshot {
             match_hits: self.match_hits.swap(0, Ordering::Relaxed),
@@ -109,6 +112,7 @@ impl PolicyStats {
             redact: self.redact.reset(),
             rename: self.rename.reset(),
             add: self.add.reset(),
+            compilation_errors: Vec::new(),
         }
     }
 }
@@ -122,6 +126,9 @@ pub struct PolicyStatsSnapshot {
     pub redact: (u64, u64),
     pub rename: (u64, u64),
     pub add: (u64, u64),
+    /// Compilation errors for this policy, if any.
+    /// Populated by the registry's stats collector from the current snapshot.
+    pub compilation_errors: Vec<String>,
 }
 
 /// A policy with its associated provider and stats.
@@ -155,6 +162,8 @@ struct SnapshotInner {
     compiled_metrics: Option<CompiledMatchers<MetricSignal>>,
     /// Compiled matchers for trace policies.
     compiled_traces: Option<CompiledMatchers<TraceSignal>>,
+    /// Per-policy compilation errors collected across all signal batches.
+    compilation_errors: HashMap<String, Vec<String>>,
 }
 
 impl PolicySnapshot {
@@ -167,8 +176,18 @@ impl PolicySnapshot {
                 compiled_logs: None,
                 compiled_metrics: None,
                 compiled_traces: None,
+                compilation_errors: HashMap::new(),
             }),
         }
+    }
+
+    /// Return the compilation errors for a policy, or an empty slice if none.
+    pub fn compilation_errors_for(&self, policy_id: &str) -> &[String] {
+        self.inner
+            .compilation_errors
+            .get(policy_id)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
     }
 
     /// Get all policies.
@@ -334,10 +353,15 @@ impl RegistryInner {
         metric_policies.sort_by(|a, b| a.0.id().cmp(b.0.id()));
         trace_policies.sort_by(|a, b| a.0.id().cmp(b.0.id()));
 
+        let mut compilation_errors: HashMap<String, Vec<String>> = HashMap::new();
+
         // Compile log matchers
         let compiled_logs = if !log_policies.is_empty() {
             match CompiledMatchers::<LogSignal>::build(log_policies.into_iter()) {
-                Ok(matchers) => Some(matchers),
+                Ok(matchers) => {
+                    compilation_errors.extend(matchers.compilation_errors.clone());
+                    Some(matchers)
+                }
                 Err(e) => {
                     eprintln!("Failed to compile log policy matchers: {}", e);
                     None
@@ -350,7 +374,10 @@ impl RegistryInner {
         // Compile metric matchers
         let compiled_metrics = if !metric_policies.is_empty() {
             match CompiledMatchers::<MetricSignal>::build(metric_policies.into_iter()) {
-                Ok(matchers) => Some(matchers),
+                Ok(matchers) => {
+                    compilation_errors.extend(matchers.compilation_errors.clone());
+                    Some(matchers)
+                }
                 Err(e) => {
                     eprintln!("Failed to compile metric policy matchers: {}", e);
                     None
@@ -363,7 +390,10 @@ impl RegistryInner {
         // Compile trace matchers
         let compiled_traces = if !trace_policies.is_empty() {
             match CompiledMatchers::<TraceSignal>::build(trace_policies.into_iter()) {
-                Ok(matchers) => Some(matchers),
+                Ok(matchers) => {
+                    compilation_errors.extend(matchers.compilation_errors.clone());
+                    Some(matchers)
+                }
                 Err(e) => {
                     eprintln!("Failed to compile trace policy matchers: {}", e);
                     None
@@ -380,6 +410,7 @@ impl RegistryInner {
                 compiled_logs,
                 compiled_metrics,
                 compiled_traces,
+                compilation_errors,
             }),
         };
 
@@ -442,7 +473,13 @@ impl PolicyRegistry {
             let snapshot = inner.snapshot();
             snapshot
                 .iter()
-                .map(|entry| (entry.policy.id().to_string(), entry.stats.reset_all()))
+                .map(|entry| {
+                    let id = entry.policy.id().to_string();
+                    let mut stats = entry.stats.reset_all();
+                    stats.compilation_errors =
+                        snapshot.compilation_errors_for(&id).to_vec();
+                    (id, stats)
+                })
                 .collect()
         });
         provider.set_stats_collector(collector);

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -476,8 +476,7 @@ impl PolicyRegistry {
                 .map(|entry| {
                     let id = entry.policy.id().to_string();
                     let mut stats = entry.stats.reset_all();
-                    stats.compilation_errors =
-                        snapshot.compilation_errors_for(&id).to_vec();
+                    stats.compilation_errors = snapshot.compilation_errors_for(&id).to_vec();
                     (id, stats)
                 })
                 .collect()
@@ -870,12 +869,16 @@ mod tests {
 
         let snapshot = registry.snapshot();
         // The policy still appears in the snapshot even though it failed to compile.
-        assert!(snapshot.get("broken").is_some(), "invalid policy still in snapshot");
+        assert!(
+            snapshot.get("broken").is_some(),
+            "invalid policy still in snapshot"
+        );
         let errs = snapshot.compilation_errors_for("broken");
         assert!(!errs.is_empty(), "compilation errors must be in snapshot");
         assert!(
             errs[0].contains("invalid regex"),
-            "error must describe the problem: {}", errs[0]
+            "error must describe the problem: {}",
+            errs[0]
         );
     }
 
@@ -960,7 +963,8 @@ mod tests {
         );
         assert!(
             broken.1.compilation_errors[0].contains("invalid regex"),
-            "error text must be preserved: {}", broken.1.compilation_errors[0]
+            "error text must be preserved: {}",
+            broken.1.compilation_errors[0]
         );
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -833,4 +833,134 @@ mod tests {
         assert_eq!(p1_again.1.match_hits, 0);
         assert_eq!(p1_again.1.match_misses, 0);
     }
+
+    fn make_log_policy_with_invalid_regex(id: &str) -> Policy {
+        use crate::proto::tero::policy::v1::{
+            LogMatcher, LogTarget, Policy as ProtoPolicy, log_matcher,
+        };
+        let proto = ProtoPolicy {
+            id: id.to_string(),
+            name: id.to_string(),
+            enabled: true,
+            target: Some(crate::proto::tero::policy::v1::policy::Target::Log(
+                LogTarget {
+                    r#match: vec![LogMatcher {
+                        field: Some(log_matcher::Field::LogField(
+                            crate::proto::tero::policy::v1::LogField::Body.into(),
+                        )),
+                        r#match: Some(log_matcher::Match::Regex("([unclosed".to_string())),
+                        negate: false,
+                        case_insensitive: false,
+                    }],
+                    keep: "none".to_string(),
+                    transform: None,
+                    sample_key: None,
+                },
+            )),
+            ..Default::default()
+        };
+        Policy::new(proto)
+    }
+
+    #[test]
+    fn invalid_policy_compilation_errors_appear_in_snapshot() {
+        let registry = PolicyRegistry::new();
+        let handle = registry.register_provider();
+        handle.update(vec![make_log_policy_with_invalid_regex("broken")]);
+
+        let snapshot = registry.snapshot();
+        // The policy still appears in the snapshot even though it failed to compile.
+        assert!(snapshot.get("broken").is_some(), "invalid policy still in snapshot");
+        let errs = snapshot.compilation_errors_for("broken");
+        assert!(!errs.is_empty(), "compilation errors must be in snapshot");
+        assert!(
+            errs[0].contains("invalid regex"),
+            "error must describe the problem: {}", errs[0]
+        );
+    }
+
+    #[test]
+    fn invalid_policy_does_not_block_valid_peer() {
+        use crate::proto::tero::policy::v1::{
+            LogMatcher, LogTarget, Policy as ProtoPolicy, log_matcher,
+        };
+
+        let valid = Policy::new(ProtoPolicy {
+            id: "valid".to_string(),
+            name: "valid".to_string(),
+            enabled: true,
+            target: Some(crate::proto::tero::policy::v1::policy::Target::Log(
+                LogTarget {
+                    r#match: vec![LogMatcher {
+                        field: Some(log_matcher::Field::LogField(
+                            crate::proto::tero::policy::v1::LogField::Body.into(),
+                        )),
+                        r#match: Some(log_matcher::Match::Exact("error".to_string())),
+                        negate: false,
+                        case_insensitive: false,
+                    }],
+                    keep: "none".to_string(),
+                    transform: None,
+                    sample_key: None,
+                },
+            )),
+            ..Default::default()
+        });
+
+        let registry = PolicyRegistry::new();
+        let handle = registry.register_provider();
+        handle.update(vec![make_log_policy_with_invalid_regex("broken"), valid]);
+
+        let snapshot = registry.snapshot();
+        assert_eq!(snapshot.len(), 2, "both policies are in the snapshot");
+        // Valid policy compiles — compiled_log_matchers is Some with 1 policy
+        let matchers = snapshot
+            .compiled_log_matchers()
+            .expect("log matchers compiled despite broken peer");
+        assert_eq!(matchers.policies.len(), 1);
+        assert_eq!(matchers.policies[0].id, "valid");
+        // Broken policy has errors, valid does not
+        assert!(!snapshot.compilation_errors_for("broken").is_empty());
+        assert!(snapshot.compilation_errors_for("valid").is_empty());
+    }
+
+    #[test]
+    fn stats_collector_includes_compilation_errors() {
+        use crate::provider::{PolicyCallback, PolicyProvider, StatsCollector};
+        use std::sync::RwLock;
+
+        struct SpyProvider {
+            policies: Vec<Policy>,
+            collector: RwLock<Option<StatsCollector>>,
+        }
+        impl PolicyProvider for SpyProvider {
+            fn set_stats_collector(&self, c: StatsCollector) {
+                *self.collector.write().unwrap() = Some(c);
+            }
+            fn subscribe(&self, callback: PolicyCallback) -> Result<(), PolicyError> {
+                callback(self.policies.clone());
+                Ok(())
+            }
+        }
+
+        let provider = SpyProvider {
+            policies: vec![make_log_policy_with_invalid_regex("broken")],
+            collector: RwLock::new(None),
+        };
+
+        let registry = PolicyRegistry::new();
+        registry.subscribe(&provider).unwrap();
+
+        let collector = provider.collector.read().unwrap();
+        let stats = collector.as_ref().unwrap()();
+        let broken = stats.iter().find(|(id, _)| id == "broken").unwrap();
+        assert!(
+            !broken.1.compilation_errors.is_empty(),
+            "compilation errors must flow through stats collector"
+        );
+        assert!(
+            broken.1.compilation_errors[0].contains("invalid regex"),
+            "error text must be preserved: {}", broken.1.compilation_errors[0]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Implements the error-handling spec from policy spec v1.5 §Error Handling.

- **Compilation errors are now collected per-policy** rather than aborting the whole batch. An invalid policy is skipped (inert) but other policies in the same batch continue to compile and evaluate normally.
- **Invalid regex patterns are pre-validated** using Vectorscan's `hs_compile` before batch compilation, so a bad regex in one policy can't take down the entire Vectorscan database for a field.
- **Errors are surfaced via `PolicySyncStatus.errors`** — the field was always there in the proto but always populated with `vec![]`. Now it contains human-readable location strings like `"log: match[0]: invalid regex \"([a-z\": ..."`
- **`PolicyStatsSnapshot` gains a `compilation_errors` field** filled in by the registry's stats collector from the current snapshot. Policies with compilation errors appear in sync status even with zero match counters, as required by the spec.

Error string format follows the spec examples:
```
log: match[0]: attribute has empty path
log: match[1]: invalid regex "([a-z": <vectorscan reason>
trace: keep: <reason>
log: transform: invalid policy 'id': invalid redact regex '...': <reason>
```

## Test plan

- [ ] All 367 existing tests pass (the 3 "empty match list rejected" tests are renamed to "collected" with new assertions)
- [ ] Verify invalid regex in a log policy does not block valid policies from matching
- [ ] Verify `PolicySyncStatus.errors` is populated for broken policies via grpc/http provider sync