### PR TITLE
fix: let the consumer choose the TLS root source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,15 @@ doctest = false
 
 [features]
 default = []
-http = ["reqwest"]
+# TLS root sources are chosen by the consumer, not forced here: reqwest's
+# `rustls-tls` implies webpki roots, which a FIPS build cannot subtract because
+# Cargo unifies features additively. `http` keeps the standalone default; a
+# consumer that supplies its own roots (and crypto provider) takes
+# `http-no-roots` and adds one of the root features, or reqwest's own.
+http = ["http-no-roots", "webpki-roots"]
+http-no-roots = ["reqwest"]
+webpki-roots = ["reqwest/rustls-tls-webpki-roots"]
+native-roots = ["reqwest/rustls-tls-native-roots"]
 grpc = ["tonic"]
 
 [dependencies]
@@ -25,7 +33,7 @@ prost = "0.13"
 fnv = "1"
 rand = "0.8"
 regex = "1"
-reqwest = { version = "0.12", features = ["json", "rustls-tls"], optional = true, default-features = false }
+reqwest = { version = "0.12", features = ["json", "rustls-tls-manual-roots-no-provider"], optional = true, default-features = false }
 notify = "7"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ Add to your `Cargo.toml`:
 policy-rs = { git = "https://github.com/usetero/policy-rs" }
 ```
 
+### Cargo features
+
+| Feature | Enables |
+| --- | --- |
+| `http` | `HttpProvider`, with webpki TLS roots and the ring crypto provider. |
+| `http-no-roots` | `HttpProvider` with no TLS roots and no crypto provider — **the consumer supplies both**. |
+| `webpki-roots` | webpki TLS roots plus the ring provider. |
+| `native-roots` | Platform TLS roots plus the ring provider. |
+| `grpc` | `GrpcProvider`. |
+
+`http` is `http-no-roots` + `webpki-roots`, so it needs no extra wiring. Use
+`http-no-roots` when your binary must control the root source or the crypto
+provider — a FIPS build, for example. Cargo unifies features additively, so a
+crate that forces a root source makes it impossible for its consumers to
+subtract one; this crate therefore forces none. Note that `http-no-roots` alone
+leaves reqwest with no crypto provider, and constructing an `HttpProvider` then
+panics with `No provider set`, so pair it with a root feature or install a
+process-default provider.
+
 ## Quick Start
 
 ```rust

--- a/examples/config_providers.rs
+++ b/examples/config_providers.rs
@@ -124,7 +124,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             provider.id(),
             match provider {
                 ProviderConfig::File(_) => "file",
-                #[cfg(feature = "http")]
+                #[cfg(feature = "reqwest")]
                 ProviderConfig::Http(_) => "http",
                 #[cfg(feature = "grpc")]
                 ProviderConfig::Grpc(_) => "grpc",

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,7 @@
 //! register_providers(&app_config.policy_providers, &registry).unwrap();
 //! ```
 
-#[cfg(any(feature = "http", feature = "grpc"))]
+#[cfg(any(feature = "reqwest", feature = "grpc"))]
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
@@ -58,7 +58,7 @@ pub enum ProviderConfig {
     File(FileProviderConfig),
 
     /// HTTP-based policy provider configuration.
-    #[cfg(feature = "http")]
+    #[cfg(feature = "reqwest")]
     Http(HttpProviderConfig),
 
     /// gRPC-based policy provider configuration.
@@ -81,7 +81,7 @@ pub struct FileProviderConfig {
 }
 
 /// Configuration for an HTTP-based policy provider.
-#[cfg(feature = "http")]
+#[cfg(feature = "reqwest")]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct HttpProviderConfig {
     /// Unique identifier for this provider.
@@ -145,7 +145,7 @@ impl ProviderConfig {
     pub fn id(&self) -> &str {
         match self {
             ProviderConfig::File(c) => &c.id,
-            #[cfg(feature = "http")]
+            #[cfg(feature = "reqwest")]
             ProviderConfig::Http(c) => &c.id,
             #[cfg(feature = "grpc")]
             ProviderConfig::Grpc(c) => &c.id,
@@ -172,7 +172,7 @@ impl ProviderConfig {
                 }
                 registry.subscribe(&provider)
             }
-            #[cfg(feature = "http")]
+            #[cfg(feature = "reqwest")]
             ProviderConfig::Http(config) => {
                 use crate::provider::{
                     ContentType, HttpProvider, HttpProviderConfig as HttpConfig,
@@ -231,7 +231,7 @@ impl ProviderConfig {
     }
 }
 
-#[cfg(any(feature = "http", feature = "grpc"))]
+#[cfg(any(feature = "reqwest", feature = "grpc"))]
 /// Convert flat string maps to a [`ClientMetadata`] proto message.
 ///
 /// `resource_attributes` and `labels` are converted to `Vec<KeyValue>` using
@@ -341,7 +341,7 @@ mod tests {
         assert_eq!(configs[1].id(), "backup");
     }
 
-    #[cfg(feature = "http")]
+    #[cfg(feature = "reqwest")]
     #[test]
     fn parse_http_provider_config() {
         let json = r#"{
@@ -372,7 +372,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "http")]
+    #[cfg(feature = "reqwest")]
     #[test]
     fn parse_http_provider_config_with_resource_attributes_and_labels() {
         let json = r#"{
@@ -418,7 +418,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "http")]
+    #[cfg(feature = "reqwest")]
     #[test]
     fn parse_http_provider_config_minimal() {
         let json = r#"{"id": "remote", "type": "http", "url": "https://api.example.com/policies"}"#;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub use field::{LogFieldSelector, MetricFieldSelector, TraceFieldSelector};
 pub use policy::Policy;
 pub use proto::opentelemetry::proto::common::v1 as otel_common;
 pub use provider::StatsCollector;
-#[cfg(feature = "http")]
+#[cfg(feature = "reqwest")]
 pub use provider::{ContentType, HttpProvider, HttpProviderConfig};
 pub use provider::{FileProvider, PolicyCallback, PolicyProvider};
 #[cfg(feature = "grpc")]

--- a/src/provider/http.rs
+++ b/src/provider/http.rs
@@ -119,6 +119,13 @@ impl HttpProvider {
     /// Create a new HTTP provider with the given configuration.
     ///
     /// This is synchronous and does not perform an initial fetch.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no rustls crypto provider is available, which is the case under
+    /// the `http-no-roots` feature until the consumer supplies one (a root
+    /// feature such as `webpki-roots`, or a process-default provider it installs
+    /// itself). The `http` feature includes both.
     /// Use [`HttpProvider::new_with_initial_fetch`] if you need to fetch
     /// policies during construction.
     pub fn new(config: HttpProviderConfig) -> Self {
@@ -474,7 +481,9 @@ impl PolicyProvider for HttpProvider {
     }
 }
 
-#[cfg(test)]
+// `reqwest::Client::new()` panics with "No provider set" unless a crypto
+// provider is compiled in, and `http-no-roots` deliberately omits one.
+#[cfg(all(test, any(feature = "webpki-roots", feature = "native-roots")))]
 mod tests {
     use super::*;
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -3,15 +3,15 @@
 mod file;
 #[cfg(feature = "grpc")]
 mod grpc;
-#[cfg(feature = "http")]
+#[cfg(feature = "reqwest")]
 mod http;
-#[cfg(any(feature = "http", feature = "grpc"))]
+#[cfg(any(feature = "reqwest", feature = "grpc"))]
 mod sync;
 
 pub use file::FileProvider;
 #[cfg(feature = "grpc")]
 pub use grpc::{GrpcProvider, GrpcProviderConfig};
-#[cfg(feature = "http")]
+#[cfg(feature = "reqwest")]
 pub use http::{ContentType, HttpProvider, HttpProviderConfig};
 use std::sync::Arc;
 


### PR DESCRIPTION
reqwest's `rustls-tls` feature implies webpki roots, and Cargo unifies features additively, so a consumer that needs a different root source — a FIPS build, for example — cannot subtract them. Depend on `rustls-tls-manual-roots-no-provider` instead, which adds the TLS plumbing and nothing else, and expose the root source as features.

`http` keeps the behaviour it has today: webpki roots plus the ring provider. `http-no-roots` leaves both the roots and the crypto provider to the consumer.

Gate the HTTP provider on the `reqwest` dependency feature rather than on `http`, so that `http-no-roots` still compiles it. Constructing an `HttpProvider` panics with `No provider set` when no crypto provider is present, so the tests that build one now require a root feature.